### PR TITLE
fix(bp): first green SC944D BP build with m68k-elf-gcc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# XC8 installer (not redistributable, ~94 MB)
+xc8-*.run
+
+# Build artifacts
+bp/build/
+bp/*.a
+bp/*.elf
+bp/*.s19
+bp/*.map
+ba/*.hex
+ba/*.o
+ba/*.lst
+ba/*.map
+
+# Test binaries
+tests/bp/test_*
+!tests/bp/test_*.c
+tests/ba/test_*
+!tests/ba/test_*.c
+tests/integration/test_*
+!tests/integration/test_*.c
+
+# macOS / editor / session junk
+.DS_Store
+.cursor/
+bp/.mqx_patched
+
+# Debug logs & captured job output (not source)
+*.zip
+logs_extracted/
+job_info.json
+job_log.txt
+log.txt
+run_logs.txt
+combined.patch

--- a/EVALUATION.md
+++ b/EVALUATION.md
@@ -1,0 +1,239 @@
+# Évaluation — build Docker headless du firmware ColdFire SC944D
+
+> Objectif : build 100 % reproductible, conteneurisé, non-interactif du firmware
+> `BP_MQX_ETH` de la carte `essensys-board-SC944D`. Trois pistes tranchées
+> **sur la base du code réel** (chemins cités), pas de suppositions.
+>
+> Date : 2026-07-28. Faits vérifiés depuis les dépôts locaux
+> `~/ESSENSYS/essensys-gcc`, `~/ESSENSYS/essensys-board-SC944D`,
+> `~/Projects/client-essensys-legacy`, et `~/ESSENSYS/essensys-doc`.
+
+---
+
+## TL;DR — recommandation
+
+**Piste C (GCC bare-metal `m68k-elf-gcc`)**, déjà matérialisée par ce dépôt
+`essensys-gcc`. Un build vert de `BP_MQX_ETH.elf/.s19` a été produit cette
+session dans Docker, sans IDE ni licence. Piste A (CodeWarrior Linux) est
+incertaine sur deux points bloquants (existence réelle d'un binaire `mwcc`/`mwld`
+Linux + licence FLEXlm en conteneur éphémère) et conserve le verrou EWL.
+Piste B (MCUXpresso) est **fermée** : MCUXpresso ne cible que les cœurs ARM,
+pas ColdFire (m68k).
+
+---
+
+## Phase 1 — Investigation (faits sourcés)
+
+### 1.1 Cible matérielle exacte
+
+| Fait | Valeur | Source |
+|------|--------|--------|
+| MCU | **Freescale MCF52259CAG80** | `essensys-doc/archi/hardware-sc944d.md` (table « Microcontroleur ») |
+| Cœur | **ColdFire V2**, 32-bit, 80 MHz | idem |
+| Mémoire | 512 KB Flash interne, 64 KB SRAM | idem |
+| `-proc` compilateur | **`52259`** | `essensys-board-SC944D/SC944D/Prog/099-37/BP_MQX_ETH/m52259evb_Int_Flash_Debug/C/crc.args` : `-proc 52259` |
+| RTOS | MQX (4.0 côté migration, 3.8 d'origine) | `essensys-gcc/README.md`, `docs/mqx-4.0-vs-4.2.md` |
+
+> ⚠️ **Nuance Piste A** : le part est **ColdFire V2** (famille MCF522xx). « ColdFire+ »
+> désigne la famille **MCF51xx (V1)** — ce n'est PAS ce MCU. « CodeWarrior for
+> ColdFire v7.2 » (classique, Metrowerks) supporte bien le MCF5225x, mais
+> l'étiquette « ColdFire+ » de la piste pré-identifiée est imprécise et doit être
+> levée avant tout choix (voir Phase 2.A).
+
+### 1.2 Système de build actuel
+
+Deux réalités coexistent :
+
+- **Firmware d'origine (CodeWarrior, déployé)** : projet **Eclipse CDT managed build**.
+  - `essensys-board-SC944D/SC944D/Prog/099-37/BP_MQX_ETH/.project` →
+    `org.eclipse.cdt.managedbuilder.core.genmakebuilder`
+  - `.cproject` → toolchain `com.freescale.coldfire.*` (« ColdFire Compiler /
+    Linker / Assembler », `coldfire.toolchain.burner`)
+  - `makefile` + `subdir.mk` + `*.args` **générés** par l'IDE (non éditables à la main).
+  - Versions archivées : `Prog/099-37/`, `Prog/_Archives/{095-34,096-35,097-36}/`
+    (schéma de version aligné sur les logs OVH `fw-vVERSION-TENTATIVE`).
+- **Migration GCC (ce dépôt `essensys-gcc`)** : Makefiles écrits à la main + Docker
+  multi-stage + CI. `essensys-gcc/bp/Makefile`, `Dockerfile`, `build.sh`.
+- **Sources firmware** : le code C métier (Alarme, Chauffage, FilPilote, TeleInfo,
+  Ethernet/RTCS, cryptage Rijndael/MD5…) vit dans
+  `client-essensys-legacy/{C,Ethernet}/*.c` (≈ 30 unités, cf. la liste dans
+  `BP_MQX_ETH.args`).
+
+### 1.3 Toolchain réellement utilisée (CodeWarrior)
+
+Invocation réelle extraite des `.args` générés (source de vérité) :
+
+`.../m52259evb_Int_Flash_Debug/C/crc.args` (compilation) :
+```
+-proc 52259
+-lavender model=ewl ,print=int ,scan=int ,io=raw
+-I"$(MCUToolsBaseDirEnv)/ColdFire_Support/ewl/EWL_C/include"
+-DDEBUG -opt level=0 -opt space -align coldfire -sdata 0
+-define __CODEWARRIOR__=1 -define _DEBUG=1
+```
+
+`.../m52259evb_Int_Flash_Debug/BP_MQX_ETH.args` (link) :
+```
+-sym full -msgstyle parseable -proc 52259
+-lavender model=ewl ,print=int ,scan=int ,io=raw
+-nostdlib "$(BSP)/intflash.lcf" -m ___boot
+-L"$(DEBUG)/rtcs" -L"$(MCUToolsBaseDirEnv)/ColdFire_Support/ewl/lib"
+```
+
+→ Compilateur/linker **Metrowerks `mwcc`/`mwld`** (flags `-proc`, `-lavender`,
+`-msgstyle parseable`, `-opt space`, `-align coldfire`, `-sdata`). Fichier de
+link **`intflash.lcf`** (format CodeWarrior). Point d'entrée `___boot`.
+
+### 1.4 Dépendances propriétaires CodeWarrior (facteur de verrou)
+
+| Dépendance | Preuve | Impact |
+|------------|--------|--------|
+| **EWL** (Embedded Warrior Library) | `-lavender model=ewl`, `-L".../ColdFire_Support/ewl/lib"`, includes `EWL_C/include` | libc propriétaire → **à remplacer** (newlib) pour sortir de CW |
+| `#pragma define_section … far_absolute` | `client-essensys-legacy/C/bootloader.c:16-39` (`.APP_JUMP`/`.APP_CRC`/`.APP_VERSION`) | placement absolu → `__attribute__((section))` en GCC |
+| `asm { … }` Metrowerks | `bootloader.c:19` `asm void APP_CALL(void){ jmp __boot; }` | asm inline → syntaxe GAS |
+| `intflash.lcf` (linker CW) | `BP_MQX_ETH.args` | → linker script GNU `.ld` |
+| Autres `#pragma` (align packed, interrupt) | `essensys-board-SC944D/BUILD_ON_LINUX.md` § « Porting to GCC » | → attributs GCC |
+
+C'est le niveau de couplage EWL + pragmas + `.lcf` qui déciderait d'un
+enfermement CodeWarrior — **mais** ce dépôt démontre que le portage est faisable
+(voir 1.5 / Piste C).
+
+### 1.5 Rôle exact de `essensys-gcc` → ouvre la Piste C
+
+`essensys-gcc` **est une vraie migration GCC ColdFire bare-metal fonctionnelle**,
+pas une abstraction :
+
+- Toolchain : **`m68k-elf-gcc`** construite depuis **crosstool-NG 1.26.0**
+  (`Dockerfile`, stage `toolchain-builder`). Cible bare-metal ELF, **newlib**
+  (remplace EWL). Vérifié : la collision `strlcpy`/`strdup` RTCS↔newlib a dû être
+  résolue (`bp/patches/0001-mqx-gcc-compat.patch`).
+- Linker : **`bp/intflash.ld`** (remplace `intflash.lcf`), avec sections
+  bootloader `.APP_CRC/.APP_VERSION/.APP_JUMP` @ 0x3000 et vecteurs @ 0x3010
+  (aligné sur le firmware déployé).
+- Pragmas portés : `bp/bootloader.c` reproduit le `bootloader.c` legacy en
+  attributs GCC ; patch MQX (`;`→`|` pour GAS, `movec` ColdFire en immédiats,
+  macros GAS…) dans `bp/patches/0001-mqx-gcc-compat.patch`.
+- **Preuve de build** (cette session, dans Docker) :
+  `BP_MQX_ETH-local-dev.elf/.s19/.map`, `text=28440 data=88 bss=64`, dans le
+  budget Flash 512 K / SRAM 64 K. `make test` (host) vert.
+
+> État : la **chaîne** est prouvée sur une application minimale. Restent à
+> intégrer les ~30 sources métier (`client-essensys-legacy/{C,Ethernet}/*.c`),
+> l'injection CRC-16 post-link, et la validation matérielle JTAG/BDM
+> (cf. issue essensys-gcc #14).
+
+---
+
+## Phase 2 — Évaluation des pistes
+
+### Piste A — CodeWarrior for ColdFire v7.2 « Linux »
+
+- **Compatibilité code** : ✅ native (c'est la toolchain d'origine ; `.project`/
+  `.cproject`/`.args` sont directement buildables par CW ColdFire 7.x Eclipse).
+- **Build headless** : le managed-build CDT génère un `makefile` invocable par
+  `mwcc`/`mwld` en ligne de commande (`-proc 52259 -lavender model=ewl … intflash.lcf`),
+  ou via `ecd.bat`/`eclipsec -nosplash -application …build`. Techniquement scriptable.
+- **Blocage n°1 — Linux** : **non prouvé dans le code**. Les projets sont orientés
+  Windows (`$(MCUToolsBaseDirEnv)`, chemins CW MCU). L'existence d'un binaire
+  `mwcc`/`mwld` **Linux** pour CW ColdFire v7.2 est à vérifier auprès des release
+  notes NXP — **à lever avant de retenir A**.
+- **Blocage n°2 — Licence FLEXlm** : CW ColdFire est sous licence FLEXlm. En
+  conteneur éphémère, seul un **serveur flottant** (`LM_LICENSE_FILE=port@host`)
+  est viable ; node-locked (hostid MAC) et dongle USB sont incompatibles avec un
+  Docker sans état. Ajoute une dépendance réseau/serveur → casse l'objectif
+  « offline-friendly, sans état ».
+- **Verrou EWL conservé** : on reste prisonnier de la lib propriétaire.
+- **Install silencieuse Dockerfile** : installeur CW historiquement InstallAnywhere
+  (mode `-i silent` possible **si** édition Linux existe) — conditionné au blocage n°1.
+
+### Piste B — MCUXpresso IDE → **FERMÉE**
+
+- **Devices supportés** : MCUXpresso IDE cible exclusivement les cœurs **ARM**
+  (Cortex-M / Cortex-A : Kinetis, LPC, i.MX RT, MCX…). Il a unifié LPCXpresso +
+  Kinetis Design Studio, **tous ARM**. **ColdFire (m68k) n'y figure pas** et n'y a
+  jamais figuré ; l'outil NXP pour ColdFire reste CodeWarrior.
+- **MCF52259 dans MCUXpresso ?** → **NON**. Verdict argumenté : archi m68k hors
+  périmètre ARM de l'outil.
+- **Vérification** : liste « Supported Devices » de MCUXpresso IDE (nxp.com) —
+  aucun MCF5xxx.
+- **Conclusion** : piste écartée, sans regret.
+
+### Piste C — GCC ColdFire pur (`m68k-elf-gcc`) → **RECOMMANDÉE**
+
+- **Compatibilité code** : ✅ démontrée par `essensys-gcc` (build vert). Portage
+  EWL→newlib, `.lcf`→`.ld`, pragmas→attributs déjà faits pour la chaîne + le
+  header bootloader ; reste l'intégration des sources métier.
+- **Build headless** : `docker build` + `docker run … build.sh bp`, 0 IDE, 0 clic.
+- **Licence** : **aucune** (GPL/BSD : GCC, binutils, newlib, crosstool-NG).
+- **Reproductibilité Docker** : ✅ image multi-stage à versions épinglées,
+  offline après build initial, sans état.
+- **Piège à éviter** : le `Dockerfile` de `essensys-board-SC944D` utilise
+  `gcc-m68k-linux-gnu` (apt) — c'est un toolchain **Linux/glibc userspace**, pas
+  bare-metal ; inadapté à un firmware freestanding. `essensys-gcc` utilise le bon :
+  **`m68k-elf-gcc`** (newlib, `-ffreestanding -nostdlib`).
+
+---
+
+## Matrice de décision
+
+Notation : ✅ favorable · ⚠️ réserve · ❌ bloquant. (5 = idéal, 1 = rédhibitoire)
+
+| Piste | Compatibilité code | Build headless | Licence | Repro. Docker | Effort | Risque legacy | Verdict |
+|-------|--------------------|----------------|---------|---------------|--------|---------------|---------|
+| **A — CodeWarrior CF v7.2 Linux** | ✅ native (5) | ⚠️ scriptable mais IDE-centric (3) | ❌ FLEXlm serveur requis (2) | ⚠️ dépend licence + édition Linux non prouvée (2) | ⚠️ install/licence (3) | ✅ zéro portage (5) | ⚠️ **Repli** si portage GCC bloque ; 2 inconnues bloquantes |
+| **B — MCUXpresso** | ❌ ColdFire absent (1) | — | — | — | — | — | ❌ **Fermée** (ARM only) |
+| **C — GCC `m68k-elf-gcc`** | ✅ prouvée, métier à intégrer (4) | ✅ `docker run build.sh` (5) | ✅ aucune (5) | ✅ épinglé, offline, sans état (5) | ⚠️ intégration métier + CRC + valid. HW (3) | ⚠️ iso-fonctionnel à valider sur cible (3) | ✅ **Recommandée** |
+
+---
+
+## POC — Piste C (déjà présent dans ce dépôt, prouvé cette session)
+
+Le POC demandé **existe et fonctionne** : `essensys-gcc/Dockerfile` +
+`essensys-gcc/build.sh`. Aucun Dockerfile redondant n'est fabriqué (les faits
+priment). Versions épinglées :
+
+| Élément | Version épinglée | Où |
+|---------|------------------|-----|
+| Image de base | `debian:bookworm-slim` | `Dockerfile` (2 stages) |
+| crosstool-NG | `crosstool-ng-1.26.0` | `Dockerfile` stage `toolchain-builder` |
+| m68k-elf-gcc | config 14.2.0 — **produit 13.2.0** ⚠️ (écart à réconcilier dans `ct-ng.config`) | `ct-ng.config` |
+| binutils / newlib / gdb | 2.43 / 4.5 / 15.2 | `ct-ng.config` (commentaire `Dockerfile`) |
+| Paquets outil | `srecord`, `cppcheck`, `lcov` | `Dockerfile` stage final |
+
+Commandes (non-interactives, vérifiées) :
+```bash
+cd ~/ESSENSYS/essensys-gcc
+docker build --build-arg SKIP_XC8=1 -t essensys-builder .          # BP seul, sans XC8
+docker run --rm -e VERSION=local-dev -v "$PWD":/workspace \
+    essensys-builder build.sh bp                                    # → bp/build/bp/BP_MQX_ETH-local-dev.{elf,s19,map}
+docker run --rm -v "$PWD":/workspace essensys-builder \
+    m68k-elf-size /workspace/bp/build/bp/BP_MQX_ETH-local-dev.elf
+```
+
+> Note : `build.sh bp` (et non `make build-bp`) est le point d'entrée correct — il
+> patche `psp_comp.h` avant `make`. Premier `docker build` ≈ 30-60 min
+> (crosstool-NG), ensuite caché.
+
+---
+
+## Recommandation finale (3-5 lignes)
+
+Retenir **Piste C — `m68k-elf-gcc` bare-metal via `essensys-gcc`** : seule option
+sans licence, offline, sans état, et **déjà prouvée** (build vert cette session).
+Fermer **Piste B** (MCUXpresso = ARM only, pas de ColdFire). Garder **Piste A** en
+repli documentaire uniquement. **Principal blocker à lever** : intégrer les ~30
+sources métier `client-essensys-legacy/{C,Ethernet}/*.c` dans `bp/Makefile`
+(EWL→newlib au cas par cas), puis injection CRC-16 post-link et validation
+matérielle JTAG/BDM (issue essensys-gcc #14). Fait annexe à corriger : l'écart de
+version GCC 13.2.0 vs 14.2.0 dans `ct-ng.config`.
+
+---
+
+## Ce qui n'a PAS pu être vérifié depuis le code (à lever)
+
+1. **Existence réelle d'une édition Linux de CW ColdFire v7.2** (`mwcc`/`mwld`
+   Linux) → release notes / installeur NXP. Sans ça, Piste A tombe.
+2. **Type de licence CW disponible** (flottant vs node-locked/dongle) → sans
+   serveur FLEXlm flottant, A est incompatible Docker éphémère.
+3. **Iso-fonctionnalité GCC vs CodeWarrior sur cible** → nécessite flash JTAG/BDM
+   d'un `.s19` GCC sur un SC944D réel (aucun test HW possible sans matériel).

--- a/bp/Makefile
+++ b/bp/Makefile
@@ -62,6 +62,7 @@ INCLUDES = \
   -I $(IO)/serial \
   -I $(IO)/i2c \
   -I $(IO)/spi_legacy \
+  -I $(IO)/spi_legacy/polled \
   -I $(IO)/gpio \
   -I $(IO)/gpio/mcf5225 \
   -I $(IO)/lwgpio \
@@ -98,6 +99,7 @@ KERN_C_SRC  = $(wildcard $(MQX_SRC)/kernel/*.c)
 
 # --- BSP m52259evb ---------------------------------------------------------
 BSP_C_SRC   = $(wildcard $(BSP_DIR)/*.c)
+BSP_S_SRC   = $(wildcard $(BSP_DIR)/*.S)
 
 # --- Compat layer ----------------------------------------------------------
 COMPAT_SRC  = compat/newlib_stubs.c compat/cf_assert.c
@@ -158,15 +160,29 @@ IO_C_SRC = \
   $(IO)/rtc/rtc_mcf5225.c \
   $(IO)/rtc/rtc_mcf52xx.c \
   $(IO)/timer/timer_mcf5225.c \
+  $(IO)/timer/timer_pit.c \
   $(IO)/pcb/io_pcb.c \
   $(IO)/pcb/io_pcb2.c \
   $(IO)/pcb/mqxa/pcb_mqxa.c \
   $(IO)/io_mem/io_mem.c \
   $(IO)/io_null/io_null.c
 
+# --- FIO (high-level buffered/formatted file I/O: fopen/fread/ioctl/...) ---
+# Referenced (extern) by the io_* driver layer above (_io_fopen, _io_ioctl,
+# etc.) but lives in its own directory, not under io/.
+FIO_C_SRC = $(wildcard $(MQX_SRC)/fio/*.c)
+
 # --- RTCS TCP/IP stack -----------------------------------------------------
+# The FTP *server* (ftpsrv_*.c) requires MFS (MQX File System) support
+# (mfs.h, MFS_* calls) which is not part of this minimal firmware build;
+# its command dispatch table (ftpsrv_commands[]) is shared by all
+# ftpsrv_*.c files, so they must be excluded as one unit. The FTP
+# *client* (ftpc*.c/ftpclnt.c) has no such dependency and is kept.
+RTCS_APPS_EXCLUDE = ftpsrv.c ftpsrv_cmd.c ftpsrv_cmd_file.c ftpsrv_cmd_transfer.c \
+                    ftpsrv_msg.c ftpsrv_supp.c ftpsrv_task.c
 RTCS_C_SRC = \
-  $(wildcard $(RTCS_SRC)/apps/*.c) \
+  $(filter-out $(addprefix $(RTCS_SRC)/apps/,$(RTCS_APPS_EXCLUDE)), \
+    $(wildcard $(RTCS_SRC)/apps/*.c)) \
   $(wildcard $(RTCS_SRC)/if/*.c) \
   $(wildcard $(RTCS_SRC)/media/*.c) \
   $(wildcard $(RTCS_SRC)/nat/*.c) \
@@ -188,9 +204,15 @@ PSP_OBJS  = $(patsubst ../%, $(BUILDDIR)/%, $(PSP_C_SRC:.c=.o)) \
             $(patsubst ../%, $(BUILDDIR)/%, $(PSP_S_SRC:.S=.o)) \
             $(patsubst ../%, $(BUILDDIR)/%, $(KERN_C_SRC:.c=.o))
 
+# Note: BSP_S_SRC objects use a distinct ".asm.o" suffix (not ".o") because
+# some BSP .S files share a basename with a sibling .c file (e.g. boot.S /
+# boot.c) — using ".o" for both would collide on the same object path and
+# silently drop the assembly file from the build (only one rule would fire).
 BSP_OBJS  = $(addprefix $(BUILDDIR)/, $(BSP_C_SRC:.c=.o)) \
+            $(addprefix $(BUILDDIR)/, $(BSP_S_SRC:.S=.asm.o)) \
             $(addprefix $(BUILDDIR)/, $(COMPAT_SRC:.c=.o)) \
-            $(patsubst ../%, $(BUILDDIR)/%, $(IO_C_SRC:.c=.o))
+            $(patsubst ../%, $(BUILDDIR)/%, $(IO_C_SRC:.c=.o)) \
+            $(patsubst ../%, $(BUILDDIR)/%, $(FIO_C_SRC:.c=.o))
 
 RTCS_OBJS = $(patsubst ../%, $(BUILDDIR)/%, $(RTCS_C_SRC:.c=.o))
 
@@ -231,7 +253,7 @@ rtcs.a: $(RTCS_OBJS)
 $(ARTIFACT_DIR)/$(TARGET_ELF): psp.a bsp.a rtcs.a $(APP_OBJS)
 	@mkdir -p $(ARTIFACT_DIR)
 	$(CC) $(LDFLAGS) -o $@ $(APP_OBJS) \
-	  -Wl,--start-group psp.a bsp.a rtcs.a -lgcc -Wl,--end-group
+	  -Wl,--start-group psp.a bsp.a rtcs.a -lc -lgcc -Wl,--end-group
 
 # --- S-record output --------------------------------------------------------
 
@@ -265,6 +287,10 @@ $(BUILDDIR)/%.o: ../%.S | .mqx_patched
 $(BUILDDIR)/%.o: %.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILDDIR)/%.asm.o: %.S
+	@mkdir -p $(dir $@)
+	$(AS) $(ASFLAGS) -c $< -o $@
 
 # ===========================================================================
 #  Auto-generated dependencies

--- a/bp/Makefile
+++ b/bp/Makefile
@@ -192,7 +192,9 @@ RTCS_C_SRC = \
   $(wildcard $(RTCS_SRC)/tcpip/*.c)
 
 # --- Application (minimal test application, will be replaced with full sources) ---
-APP_SRC  = main.c
+# bootloader.c emits the fixed-address header sections (.APP_CRC/.APP_VERSION/
+# .APP_JUMP @ 0x3000) that the existing bootloader reads before launching.
+APP_SRC  = main.c bootloader.c
 APP_OBJS = $(addprefix $(BUILDDIR)/, $(APP_SRC:.c=.o))
 
 # ===========================================================================

--- a/bp/bootloader.c
+++ b/bp/bootloader.c
@@ -1,0 +1,42 @@
+/*
+ * bootloader.c — Application header at fixed flash address 0x3000.
+ *
+ * GCC/GAS port of the legacy CodeWarrior C/bootloader.c. Emits the three
+ * fixed-address sections the existing Essensys bootloader reads before it
+ * launches the application image:
+ *
+ *   0x3000  .APP_CRC       unsigned short  CRC-16 of the application zone
+ *   0x3002  .APP_VERSION   unsigned short  firmware version number
+ *   0x3004  .APP_JUMP      jmp __boot      entry trampoline (6 bytes)
+ *
+ * Placement is enforced by bp/intflash.ld (.app_header @ 0x3000, ordered
+ * CRC, VERSION, JUMP). The bootloader computes CRC-16 over 0x3002–0x7DFFF
+ * and compares it against the halfword at 0x3000, then jumps to 0x3004.
+ *
+ * CRC is a placeholder here: the real value is injected post-link by the
+ * CRC tool (as in the legacy build, where CodeWarrior stored 0x0102 and the
+ * flashing/OTA step patched it). VERSION is a build-time constant.
+ */
+
+/* Defined in bp/bsp/m52259evb/boot.S (.global __boot). */
+extern void __boot(void);
+
+/* 0x3000 — CRC-16 placeholder, overwritten post-link by the CRC tool. */
+__attribute__((section(".APP_CRC"), used))
+const unsigned short APP_CRC = 0x0102;
+
+/* 0x3002 — firmware version. Placeholder for this minimal build; the
+ * metier build supplies the real us_BP_VERSION_SERVEUR. */
+__attribute__((section(".APP_VERSION"), used))
+const unsigned short APP_VERSION = 0x0000;
+
+/* 0x3004 — `jmp __boot` trampoline. m68k-elf-gcc ignores the `naked`
+ * attribute, but at -Os this leaf function needs no frame, so GCC emits the
+ * inline `jmp __boot` at offset 0 (verified: 4ef9 0000 xxxx = 6-byte absolute
+ * long jump, matching the legacy .APP_JUMP size) followed by an unreachable
+ * `rts`. The bootloader jumps to 0x3004 and control transfers immediately. */
+__attribute__((section(".APP_JUMP"), used))
+void APP_CALL(void)
+{
+    __asm__ __volatile__("jmp __boot");
+}

--- a/bp/bsp/m52259evb/boot.S
+++ b/bp/bsp/m52259evb/boot.S
@@ -7,17 +7,21 @@
  *
  * Assembled with:  m68k-elf-gcc -mcpu=52259 -Wa,--register-prefix-optional
  *
- * Linker symbols required (from linker script):
+ * Linker symbols required (from linker script, see bp/intflash.ld):
  *   __BOOT_STACK_ADDRESS   Initial stack pointer (top of SRAM)
  *   __VECTOR_TABLE_ROM_START  Base of vector table in Flash
  *   __IPSBAR               Peripheral base address
  *   __INTERNAL_FLASH_BASE  Internal Flash start
  *   __INTERNAL_SRAM_BASE   Internal SRAM start
- *   __DATA_ROM             .data section LMA (load address in Flash)
- *   __DATA_RAM             .data section VMA (destination in RAM)
- *   __DATA_END             End of .data in RAM
- *   __BSS_START            Start of .bss
- *   __BSS_END              End of .bss
+ *   _sidata                .data section LMA (load address in Flash)
+ *   _sdata / _edata        .data section VMA start/end (destination in RAM)
+ *   _sbss / _ebss          .bss start/end (zero-initialized in RAM)
+ * (intflash.ld's own comments document these as the intended startup
+ *  contract: "Startup code copies LMA -> VMA using _sidata / _sdata /
+ *  _edata" and "Startup code zeroes _sbss -> _ebss". Note _sdata/_edata
+ *  span the whole .data output section (vectors_ram, usb_bdt, .data*,
+ *  .sdata*) — not just the __START_DATA/__END_DATA sub-range, which
+ *  would leave part of initialized data uncopied.)
  */
 
     .section .boot, "ax"
@@ -32,11 +36,21 @@
     .extern __IPSBAR
     .extern __INTERNAL_FLASH_BASE
     .extern __INTERNAL_SRAM_BASE
-    .extern __DATA_ROM
-    .extern __DATA_RAM
-    .extern __DATA_END
-    .extern __BSS_START
-    .extern __BSS_END
+    .extern _sidata
+    .extern _sdata
+    .extern _edata
+    .extern _sbss
+    .extern _ebss
+
+    /* ColdFire MOVEC control-register selectors.
+     * GAS's m68k register-name table only recognizes RAMBAR0/RAMBAR1
+     * mnemonics for classic 68040/68060 CPUs, not for ColdFire targets;
+     * on ColdFire these must be written as movec Rn,#<selector>. Values
+     * match the Freescale numeric constants (see
+     * mqx/source/psp/coldfire/types.inc, __ACF__ block: RAMBAR0=0xC04,
+     * RAMBAR1=0xC05). */
+    .equ    CF_RAMBAR0, 0xC04
+    .equ    CF_RAMBAR1, 0xC05
 
 /*
  * _startup / __boot — primary entry point after reset.
@@ -65,13 +79,13 @@ __boot:
     move.l  #__INTERNAL_FLASH_BASE, d0
     andi.l  #0xFFF80000, d0
     addi.l  #0x61, d0
-    movec   d0, rambar0
+    movec   d0, #CF_RAMBAR0
 
     /* RAMBAR1 — validate internal SRAM for code+data access */
     move.l  #__INTERNAL_SRAM_BASE, d0
     andi.l  #0xFFF80000, d0
     addi.l  #0x21, d0
-    movec   d0, rambar1
+    movec   d0, #CF_RAMBAR1
 
     /* Mask all interrupts in INTC0 and INTC1 */
     movea.l #__IPSBAR, a0
@@ -85,9 +99,9 @@ __boot:
     jsr     mcf5225_init
 
     /* Copy .data section from Flash (LMA) to SRAM (VMA) */
-    lea     __DATA_ROM, a0              /* source (Flash)                    */
-    lea     __DATA_RAM, a1              /* destination (SRAM)                */
-    lea     __DATA_END, a2              /* end marker                        */
+    lea     _sidata, a0                 /* source (Flash)                    */
+    lea     _sdata, a1                  /* destination (SRAM)                */
+    lea     _edata, a2                  /* end marker                        */
     bra.s   .Lcopy_check
 .Lcopy_loop:
     move.l  (a0)+, (a1)+
@@ -96,8 +110,8 @@ __boot:
     bhi.s   .Lcopy_loop
 
     /* Zero .bss section */
-    lea     __BSS_START, a0
-    lea     __BSS_END, a1
+    lea     _sbss, a0
+    lea     _ebss, a1
     moveq   #0, d0
     bra.s   .Lzero_check
 .Lzero_loop:

--- a/bp/compat/cf_assert.c
+++ b/bp/compat/cf_assert.c
@@ -1,5 +1,5 @@
-#include <bsp.h>
 #include <mqx.h>
+#include <bsp.h>
 
 #if (MQX_ASSERT == MQX_ASSERT_LOOP || MQX_ASSERT == MQX_ASSERT_BKPT)
 void _mqx_assert(const char *string, const char *func, const char *file,

--- a/bp/intflash.ld
+++ b/bp/intflash.ld
@@ -30,9 +30,11 @@ EXTERN(_cfm __init_hardware)
 
 MEMORY
 {
-    vectors     (rx)  : ORIGIN = 0x00000000, LENGTH = 0x00000400
-    cfmprotrom  (r)   : ORIGIN = 0x00000400, LENGTH = 0x00000020
-    /* 0x00000420 – 0x00002FFF : existing bootloader — intentionally unmapped */
+    /* 0x00000000 – 0x00002FFF : reset vectors, CFM config and the existing
+     * bootloader — owned by the bootloader image, NOT part of this OTA
+     * application image. Intentionally unmapped here. This firmware is
+     * flashed at 0x3000 and reached via the bootloader's jump to .APP_JUMP;
+     * its own vector table lives at 0x3010 (VBR is set to it in boot.S). */
     rom         (rx)  : ORIGIN = 0x00003000, LENGTH = 0x0004B000  /* 0x3000–0x7DFFF */
     persist     (rw)  : ORIGIN = 0x0007E000, LENGTH = 0x00001000  /* 4 KB NOLOAD    */
     sram        (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00010000  /* 64 KB          */
@@ -72,32 +74,15 @@ SECTIONS
     __FLASHX_SECT_SIZE             = 0x1000;
 
     /* ================================================================
-     *  Interrupt vector table (Flash, 0x00000000)
-     * ================================================================ */
-    .vectors :
-    {
-        __vector_table = .;
-        __VECTOR_TABLE_ROM_START = .;
-        KEEP(*(.vectors_rom))
-        . = ALIGN(0x4);
-    } > vectors
-
-    /* ================================================================
-     *  ColdFire Flash Module protection (0x00000400)
-     * ================================================================ */
-    .cfmprotect :
-    {
-        KEEP(*(.cfmconfig))
-        . = ALIGN(0x4);
-    } > cfmprotrom
-
-    /* ================================================================
-     *  Bootloader header — CRITICAL fixed-address sections
+     *  Bootloader header — CRITICAL fixed-address sections (0x3000)
      *
-     *  The existing bootloader reads these at absolute addresses:
+     *  The existing bootloader reads these at absolute addresses, then
+     *  jumps to .APP_JUMP:
      *    0x3000  CRC-16       (2 B)
      *    0x3002  Version      (2 B)
-     *    0x3004  jmp __boot   (≤ 8 B)
+     *    0x3004  jmp __boot   (6 B)
+     *  This is the FIRST thing in the application image (mirrors the
+     *  deployed CodeWarrior layout).
      * ================================================================ */
     .app_header :
     {
@@ -105,6 +90,33 @@ SECTIONS
         KEEP(*(.APP_VERSION))
         KEEP(*(.APP_JUMP))
         . = ALIGN(0x10);
+    } > rom
+
+    /* ================================================================
+     *  Application interrupt vector table (Flash, 0x3010)
+     *
+     *  Placed right after the header, matching the deployed firmware
+     *  (.vectors @ 0x3010). boot.S sets VBR = __VECTOR_TABLE_ROM_START,
+     *  so the vector base follows this section automatically.
+     * ================================================================ */
+    .vectors :
+    {
+        __vector_table = .;
+        __VECTOR_TABLE_ROM_START = .;
+        KEEP(*(.vectors_rom))
+        . = ALIGN(0x4);
+    } > rom
+
+    /* ================================================================
+     *  ColdFire Flash Module protection copy (0x3410)
+     *
+     *  The real CFM security config at 0x400 belongs to the bootloader
+     *  image; this copy mirrors the deployed application layout.
+     * ================================================================ */
+    .cfmprotect :
+    {
+        KEEP(*(.cfmconfig))
+        . = ALIGN(0x4);
     } > rom
 
     /* ================================================================

--- a/bp/main.c
+++ b/bp/main.c
@@ -14,6 +14,11 @@
 /* Stack size for tasks */
 #define MAIN_STACK_SIZE 1024
 
+/* Forward declaration: referenced by MQX_template_list below, defined later
+ * in this file. Required by GCC (unlike CodeWarrior, GCC does not allow a
+ * bare identifier to be used as a value without a prior declaration). */
+void main_task(uint32_t param);
+
 /* Global task table */
 const TASK_TEMPLATE_STRUCT MQX_template_list[] = {
     /* Task Index,   Function,   Stack,      Priority,   Name,          Attributes,          Param,  Time Slice */

--- a/bp/patches/0001-mqx-gcc-compat.patch
+++ b/bp/patches/0001-mqx-gcc-compat.patch
@@ -1,3 +1,16 @@
+diff --git a/mqx/source/io/lwgpio/lwgpio_mcf5225.c b/mqx/source/io/lwgpio/lwgpio_mcf5225.c
+index b1c8c3d5..64c26b58 100644
+--- a/mqx/source/io/lwgpio/lwgpio_mcf5225.c
++++ b/mqx/source/io/lwgpio/lwgpio_mcf5225.c
+@@ -94,7 +94,7 @@ bool lwgpio_init
+         gpio_ptr[REG_SET] = &(((VMCF5225_STRUCT_PTR)_PSP_GET_IPSBAR())->GPIO.PORTTEP_SETTE);
+         gpio_ptr[REG_CLR] = &(((VMCF5225_STRUCT_PTR)_PSP_GET_IPSBAR())->GPIO.CLRTE);
+         gpio_ptr[REG_PAR] = &(((VMCF5225_STRUCT_PTR)_PSP_GET_IPSBAR())->GPIO.PTEPAR);
+-        (volatile uint32_t *)gpio_ptr[REG_PCR] = &(((VMCF5225_STRUCT_PTR)_PSP_GET_IPSBAR())->GPIO.PSRR);
++        gpio_ptr[REG_PCR] = &(((VMCF5225_STRUCT_PTR)_PSP_GET_IPSBAR())->GPIO.PSRR);
+ 
+         eport_ptr = &(((VMCF5225_STRUCT_PTR)_PSP_GET_IPSBAR())->EPORT[0]);
+         first_run = FALSE;
 diff --git a/mqx/source/psp/coldfire/asm_mac.h b/mqx/source/psp/coldfire/asm_mac.h
 index 18a2f9d6..6a3a81cc 100644
 --- a/mqx/source/psp/coldfire/asm_mac.h
@@ -46,31 +59,2754 @@ index 18a2f9d6..6a3a81cc 100644
 +
  #endif /* __asm_mac_cw_h__ */
 diff --git a/mqx/source/psp/coldfire/dispatch.S b/mqx/source/psp/coldfire/dispatch.S
-index bfe6c3bb..0881f721 100644
+index bfe6c3bb..292ea3c8 100644
 --- a/mqx/source/psp/coldfire/dispatch.S
 +++ b/mqx/source/psp/coldfire/dispatch.S
-@@ -37,10 +37,15 @@
- 
- #ifdef __ACF__
-         RSEG KERNEL:CODE (4)
+@@ -1,1328 +1,1346 @@
+-;*HEADER********************************************************************
+-;*
+-;* Copyright 2008 Freescale Semiconductor, Inc.
+-;* Copyright 1989-2008 ARC International
+-;*
+-;* This software is owned or controlled by Freescale Semiconductor.
+-;* Use of this software is governed by the Freescale MQX RTOS License
+-;* distributed with this Material.
+-;* See the MQX_RTOS_LICENSE file distributed for more details.
+-;*
+-;* Brief License Summary:
+-;* This software is provided in source form for you to use free of charge,
+-;* but it is not open source software. You are allowed to use this software
+-;* but you cannot redistribute it or derivative works of it in source form.
+-;* The software may be used only in connection with a product containing
+-;* a Freescale microprocessor, microcontroller, or digital signal processor.
+-;* See license agreement file for full license terms including other restrictions.
+-;**************************************************************************
+-;*
+-;* Comments:
+-;*
+-;*   This assembler file contains functions for task scheduling
+-;*
+-;*END***********************************************************************
+-
+-        ;.file "dispatch.s"
+-
+-#include <asm_mac.h>
+-#include "mqx_cnfg.h"
+-
+-#define __ASM__
+-#include "psp.h"
+-#undef __ASM__
+-
+-#include "types.inc"
+-#include "psp_prv.inc"
+-
+-#ifdef __ACF__
+-        RSEG KERNEL:CODE (4)
+-#else
+-        .text
+-        .section KERNEL,16,x
+-#endif
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _task_block
+-; Comments         :
+-; This function is called by a task to save its context and remove
+-; itself from its ready queue. The next runnable task in the ready queues
+-; is made active and dispatched.  The state of the task is marked as being
+-; blocked.
+-;
+-;END*------------------------------------------------------------------------
+-
+-        ASM_PUBLIC(_task_block)
+-        ASM_ALIGN(4)
+-
+-ASM_PREFIX(_task_block):
+-        SAVE_ALL_REGISTERS              ; Save the context of the active task.
+-
+-        GET_KERNEL_DATA a2              ; Get the address of kernel data
+-        movea.l (KD_ACTIVE_PTR,a2),a3    ; get active td
+-        move.w  (KD_DISABLE_SR,a2),d0    ; DISABLE INTERRUPTS
+-        move.w  d0,sr
+-        move.l  sp,(TD_STACK_PTR,a3)     ; save stack pointer
+-#if PSP_HAS_DSP
+-        SAVE_DSP_REGISTERS a3,a4        ; wipes d1
+-#endif
+-        moveq.l #1,d0                   ; Set the block bit
+-        or.l    d0,(TD_STATE,a3)
+-
+-#if MQX_KERNEL_LOGGING
+-        KLOG    a2,ASM_PREFIX(_klog_block_internal) ; kernel log this function
+-#endif
+-
+-;       Remove the active task from the ready queue.
+-        movea.l (TD_TD_PREV,a3),a1       ; get ptr to ready_q structure
+-        movea.l (TD_TD_NEXT,a3),a4
+-        move.l  a4,(RQ_HEAD_READY_Q,a1)
+-        move.l  a1,(TD_TD_PREV,a4)
+-
+-        bra.w   __sched_internal  ; Search for the next task in the ready queue.
+-
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _sched_start_internal
+-; Comments         :
+-;  This function is called from _mqx in order to start the task
+-;  scheduler running.
+-;
+-;END*------------------------------------------------------------------------
+-
+-        ASM_PUBLIC(_sched_start_internal)
+-        ASM_ALIGN(4)
+-
+-ASM_PREFIX(_sched_start_internal):
+-        GET_KERNEL_DATA a2
+-        bra.w           __sched_internal
+-
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _sched_check_scheduler_internal
+-; Comments         :
+-;    This function is called to check whether scheduling is necessary
+-; It falls through into the next function
+-;
+-; Function Name    : _sched_execute_scheduler_internal
+-; Comments         :
+-;    This function is called by a task to save its context.
+-; This is usually done when the task has already been removed from the
+-; ready queue, and is on some other queue.
+-; However it can also be called so that the current tasks context is saved
+-; so that the scheduler can run (in case of a higher priority task being
+-; available.
+-;
+-; It falls through to the next function
+-;
+-; Function Name    : _sched_internal
+-; Comments         :
+-;   This function is the actual task scheduler... IT IS NOT CALLABLE from C
+-; rather, other assembler functions in this file jump to it.
+-;
+-;END*------------------------------------------------------------------------
+-
+-        ASM_PUBLIC(_sched_check_scheduler_internal)
+-        ASM_PUBLIC(_sched_execute_scheduler_internal)
+-        ASM_PUBLIC(__sched_context_switch_internal)
+-        ASM_PUBLIC(_sched_run_internal)
+-ASM_PREFIX(_sched_run_internal):
+-        GET_KERNEL_DATA a2              ; Get address of kernel data
+-        bra.w    __sched_internal
+-
+-__sched_check_return:
+-        rts
+-        ASM_CONST16(0x0000)
+-
+-
+-        ASM_ALIGN(4)
+-ASM_PREFIX(_sched_check_scheduler_internal):
+-;       Use A0, D0: both scratch registers
+-        GET_KERNEL_DATA a0              ; Get address of kernel data
+-        move.w  (KD_IN_ISR,a0),d0
+-        bne.b   __sched_check_return    ; We are in an ISR, so return
+-        move.l  (KD_CURRENT_READY_Q,a0),d0
+-        movea.l (KD_ACTIVE_PTR,a0),a0
+-        cmp.l   (TD_MY_QUEUE,a0),d0
+-        beq.b   __sched_check_return    ; Current task is still the active task
+-
+-ASM_PREFIX(_sched_execute_scheduler_internal):
+-        SAVE_ALL_REGISTERS              ; Save the context of the active task.
+-
+-        GET_KERNEL_DATA a2              ; Get address of kernel data
+-        movea.l (KD_ACTIVE_PTR,a2),a3    ; get active td
+-        move.w  (KD_DISABLE_SR,a2),d0    ; DISABLE INTERRUPTS
+-        move.w  d0,sr
+-        move.l  sp,(TD_STACK_PTR,a3)     ; save stack pointer
+-#if PSP_HAS_DSP
+-        SAVE_DSP_REGISTERS a3,a4        ; wipes d1
+-#endif
+-
+-#if MQX_KERNEL_LOGGING
+-        KLOG    a2,ASM_PREFIX(_klog_execute_scheduler_internal) ; kernel log this function
+-#endif
+-
+-;
+-;  MAIN TASK SCHEDULER CODE
+-;  Arrive here from other assembler functions with a2 already set
+-
+-__sched_internal:
+-        move.w  (KD_DISABLE_SR,a2),d0    ; DISABLE INTERRUPTS
+-        move.w  d0,sr
+-        movea.l (KD_CURRENT_READY_Q,a2),a1  ; get current ready q
+-
+-find_nonempty_queue:
+-        movea.l (a1),a3                 ; address of first td
+-        cmpa.l  a3,a1                   ; ready_q structure itself?
+-        bne.b   activate
+-        movea.l (RQ_NEXT_Q,a1),a1        ; try next queue
+-        move.l  a1,d0
+-        bne.b   find_nonempty_queue
+-
+-       ; No task available to run
+-no_one_to_run:
+-;       Set up system task running and wait for an interrupt
+-        lea.l   (KD_SYSTEM_TD,a2),a3
+-        move.l  a3,(KD_ACTIVE_PTR,a2)
+-        move.w  #0x2000,d0
+-        move.w  d0,(KD_ACTIVE_SR,a2)
+-; Start CR 1169
+-;       move.l  KD_INTERRUPT_STACK_PTR(a2),sp
+-        GET_SYSTEM_STACK a1
+-        movea.l a1, sp
+-; End CR 1169
+-#if PSP_STOP_ON_IDLE
+-        stop    #0x2000
+-#else
+-        move.w  #0x2000,sr
+-#endif
+-
+-
+-        movea.l (KD_READY_Q_LIST,a2),a1  ; get ready just in case
+-        bra.b   find_nonempty_queue
+-
+-activate:
+-#if MQXCFG_ENABLE_FP && PSP_HAS_FPU
+-;       We now have the new task to run, check if it needs the
+-;       floating point co-processor
+-        move.w   (TD_FLAGS+2,a3),d0
+-        andi.l   #FP_TASK_MASK,d0
+-        bne.b    do_floating_point
+-#endif
+-
+-no_floating_point:
+-        move.l   a1,(KD_CURRENT_READY_Q,a2)
+-        move.l   a3,(KD_ACTIVE_PTR,a2)
+-        move.w   (TD_TASK_SR,a3),(KD_ACTIVE_SR,a2)
+-        movea.l  (TD_STACK_PTR,a3),sp     ; restore stack pointer
+-
+-#if MQX_KERNEL_LOGGING
+-        KLOG     a2,ASM_PREFIX(_klog_context_switch_internal)  ; do kernel logging
+-#endif
+-
+-#if MQX_HAS_CONTEXT_SWITCH_HANDLER
+-        move.l  a2, -(sp)
+-        jsr     ASM_PREFIX(_mqx_context_switch_internal)
+-        move.l  (sp)+, a2
+-#endif
+-
+-#if PSP_HAS_DSP
+-        RESTORE_DSP_REGISTERS a3,a0      ; kills d0
+-#endif
+-        RESTORE_ALL_REGISTERS            ; restore task context
+-__sched_context_switch_internal:
+-        rte
+-        ASM_CONST16(0x0000)
+-
+-#if MQXCFG_ENABLE_FP && PSP_HAS_FPU
+-        ASM_ALIGN(4)
+-do_floating_point:
+-;       See if a floating point task is currently active
+-        movea.l  (KD_FP_ACTIVE_PTR,a2),a4
+-        tst.l    a4
+-        beq.b    restore_fp_context
+-
+-;       See if the floating point task is in fact the task being scheduled
+-;       So, no need to save and restore pointers
+-        cmpa.l   a3,a4
+-        beq.b    no_floating_point
+-
+-;       Stop the floating point unit, and save the internal
+-;       floating point registers in the floating point context
+-;       save area allocated for the task
+-        movea.l  (TD_FLOAT_CONTEXT_PTR,a4), a0
+-        fmove.l  FPSR,(FP_FPSR_OFFSET,a0)
+-        fmove.l  FPCR,FP_FPCR_OFFSET(a0)
+-        fmove.l  FPIAR,FP_FPIAR_OFFSET(a0)
+-        fmovem   FP0-FP7,(FP_FPR0_OFFSET,a0)
+-
+-;       Indicate in TD that FP context saved
+-        move.w   (TD_FLAGS+2,a4),d0
+-        or.l     #FP_CONTEXT_SAVED_MASK,d0      ; Set the block bit
+-        move.w   d0,(TD_FLAGS+2,a4)
+-
+-restore_fp_context:
+-;       Restore the context of the current FP task if necessary
+-        move.l   a3,(KD_FP_ACTIVE_PTR,a2)
+-        move.w   (TD_FLAGS+2,a3),d0
+-        andi.l   #FP_CONTEXT_SAVED_MASK,d0
+-        beq.b    no_fp_registers_to_restore
+-
+-;       Now restore the floating point context
+-        movea.l  (TD_FLOAT_CONTEXT_PTR,a3), a0
+-
+-  #if MQX_FP_CONTEXT_CHECK
+-;       This code tests that the floating point buffer we are restoring
+-;       the floating point context from really belongs to task 'a3'.  If
+-;       the task ID's don't match then something has been corrupted.
+-;       This code can be disabled for faster performance.
+-        move.l   (TD_TASK_ID,a3),d0
+-        cmp.l    (FP_TID_OFFSET,a0),d0
+-        beq.b    fp_context_check_ok
+-        move.l   #4138,d0
+-        move.l   d0,(a7)
+-        ASM_EXTERN(ASM_PREFIX(_mqx_fatal_error))
+-        jsr (ASM_PREFIX(_mqx_fatal_error))
+-        halt
+-fp_context_check_ok:
+-  #endif
+-
+-        fmovem   (FP_FPR0_OFFSET,a0),FP0-FP7
+-        fmove.l  (FP_FPCR_OFFSET,a0),FPCR
+-        fmove.l  (FP_FPIAR_OFFSET,a0),FPIAR
+-        fmove.l  (FP_FPSR_OFFSET,a0),FPSR
+-
+-no_fp_registers_to_restore:
+-        move.w   (TD_FLAGS+2,a3),d0
+-        and.l    #FP_CONTEXT_CLEAR_MASK,d0
+-        move.w   d0,(TD_FLAGS+2,a3)
+-        jmp      (no_floating_point)
+-#endif
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _psp_save_fp_context_internal
+-; Returned Value   : none
+-; Comments         :
+-;   This function saves the floating point context for the
+-; current floating point task
+-;
+-; THIS FUNCTION MUST BE CALLED DISABLED
+-;
+-;END*----------------------------------------------------------------------
+-
+-        ASM_PUBLIC(_psp_save_fp_context_internal)
+-        ASM_ALIGN(4)
+-
+-ASM_PREFIX(_psp_save_fp_context_internal):
+-#if MQXCFG_ENABLE_FP && PSP_HAS_FPU
+-;       Stop the floating point unit, and save the internal
+-;       floating point registers on the stack of the FP task
+-        GET_KERNEL_DATA a0
+-        movea.l  (KD_FP_ACTIVE_PTR,a0),a0
+-        move.w   (TD_FLAGS+2,a0),d0
+-        andi.l   #FP_CONTEXT_SAVED_MASK,d0
+-        bne.b    _psp_save_fp_context_done
+-
+-        or.l     #FP_CONTEXT_SAVED_MASK,d0
+-        move.w   d0,(TD_FLAGS+2,a0)
+-        movea.l  (TD_FLOAT_CONTEXT_PTR,a0), a0
+-        fmove.l  FPSR,(FP_FPSR_OFFSET,a0)
+-        fmove.l  FPCR,FP_FPCR_OFFSET(a0)
+-        fmove.l  FPIAR,FP_FPIAR_OFFSET(a0)
+-        fmovem   FP0-FP7,(FP_FPR0_OFFSET,a0)
+-#endif
+-_psp_save_fp_context_done:
+-        rts
+-        ASM_CONST16(0x0000)
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _psp_set_a6_sp_and_goto
+-; Returned Value   : previous value of location
+-; Comments         :
+-;   This function tests a byte location, and if 0, sets it to 0x80.
+-;   It returns the previous value of the byte.
+-;
+-;END*----------------------------------------------------------------------
+-
+-        ASM_PUBLIC(_psp_set_a6_sp_and_goto)
+-        ASM_ALIGN(4)
+-
+-ASM_PREFIX(_psp_set_a6_sp_and_goto):
+-//#ifndef __ACF__   /* ACF uses register passing */
+-#if PSP_ABI == PSP_ABI_STD
+-   movea.l  (4,sp), a6
+-   movea.l  (12,sp), a0
+-   movea.l  (8,sp), sp
+-#else
+-   movea.l  d0, a6
+-   movea.l  d1, sp
+-   movea.l  d2, a0
+-#endif
+-   jmp      (a0)
+-   rts
+-   ASM_CONST16(0x0000)
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _mem_test_and_set
+-; Returned Value   : previous value of location
+-; Comments         :
+-;   This function tests a byte location, and if 0, sets it to 0x80.
+-;   It returns the previous value of the byte.
+-;
+-;END*----------------------------------------------------------------------
+-
+-        ASM_PUBLIC(_mem_test_and_set)
+-        ASM_ALIGN(4)
+-
+-ASM_PREFIX(_mem_test_and_set):
+-//#ifndef __ACF__   /* ACF uses register passing */
+-#if PSP_ABI == PSP_ABI_STD
+-   movea.l (4,sp),a0
+-#endif
+-   bset.b  #7,(a0)
+-   bne.b   bit_was_set
+-   clr.l   d0
+-   rts
+-   ASM_CONST16(0x0000)
+-
+-bit_was_set:
+-   move.l  #0x80,d0
+-   rts
+-   ASM_CONST16(0x0000)
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _psp_set_sr
+-; Returned Value   : none
+-; Comments         :
+-;   This function sets the sr register
+-;
+-;END*----------------------------------------------------------------------
+-        ASM_PUBLIC(__psp_set_sr)
+-        ASM_ALIGN(4)
+-
+-ASM_PREFIX(__psp_set_sr):
+-//#ifndef __ACF__   /* ACF uses register passing */
+-#if PSP_ABI == PSP_ABI_STD
+-   move.l   (4,sp),d0
+-#endif
+-   move.w   d0,sr
+-   rts
+-   ASM_CONST16(0x0000)
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _psp_get_sr
+-; Returned Value   : none
+-; Comments         :
+-;   This function gets the sr register
+-;
+-;END*----------------------------------------------------------------------
+-        ASM_PUBLIC(__psp_get_sr)
+-        ASM_ALIGN(4)
+-
+-ASM_PREFIX(__psp_get_sr):
+-   move.w   sr,d0
+-   rts
+-   ASM_CONST16(0x0000)
+-
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _psp_set_vbr
+-; Returned Value   : uint32_t vbr value
+-; Comments         :
+-;   This function sets the vbr register
+-;
+-;END*----------------------------------------------------------------------
+-        ASM_PUBLIC(_psp_set_vbr)
+-        ASM_ALIGN(4)
+-
+-ASM_PREFIX(_psp_set_vbr):
+-//#ifndef __ACF__   /* ACF uses register passing */
+-#if PSP_ABI == PSP_ABI_STD
+-   move.l   (4,sp),d0
+-#endif
+-   movec    d0, vbr
+-   rts
+-   ASM_CONST16(0x0000)
+-
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _psp_set_cpucr
+-; Returned Value   : none
+-; Comments         :
+-;   This function sets the cpucr register
+-;
+-;END*----------------------------------------------------------------------
+-        ASM_PUBLIC(_psp_set_cpucr)
+-        ASM_ALIGN(4)
+-
+-ASM_PREFIX(_psp_set_cpucr):
+-//#ifndef __ACF__   /* ACF uses register passing */
+-#if PSP_ABI == PSP_ABI_STD
+-   move.l   (4,sp),d0
+-#endif
+-;   movec    d0,cpucr
+-   ASM_CONST16(0x4E7B)
+-   ASM_CONST16(0x0802)
+-   rts
+-   ASM_CONST16(0x0000)
+-
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _psp_set_cacr
+-; Returned Value   : uint32_t cacr value
+-; Comments         :
+-;   This function sets the cacr register
+-;
+-;END*----------------------------------------------------------------------
+-        ASM_PUBLIC(_psp_set_cacr)
+-        ASM_ALIGN(4)
+-
+-ASM_PREFIX(_psp_set_cacr):
+-#ifdef __ACF__   /* ACF uses register passing */
+-   movec    d0, 0x002
+-#else
+-
+-#if PSP_ABI == PSP_ABI_STD
+-    move.l   (4,sp),d0
+-#endif
+-
+-    movec    d0, cacr
+-#endif
+-   rts
+-   ASM_CONST16(0x0000)
+-
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _psp_set_mbar
+-; Returned Value   : none
+-; Comments         :
+-;   This function sets the mbar register
+-;
+-;END*----------------------------------------------------------------------
+-        ASM_PUBLIC(_psp_set_mbar)
+-        ASM_ALIGN(4)
+-
+-ASM_PREFIX(_psp_set_mbar):
+-//#ifndef __ACF__   /* ACF uses register passing */
+-#if PSP_ABI == PSP_ABI_STD
+-   move.l   (4,sp),d0
+-#endif
+-   movec    d0, mbar
+-   rts
+-   ASM_CONST16(0x0000)
+-
+-
+-#if PSP_ACR_CNT
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _psp_set_acr
+-; Returned Value   : none
+-; Comments         :
+-;   This function sets the specified acr register
+-;
+-;END*----------------------------------------------------------------------
+-
+-        ASM_PUBLIC(_psp_set_acr)
+-        ASM_EXTERN(_psp_saved_acr0)
+-        ASM_EXTERN(_psp_saved_acr1)
+-
+-#if PSP_ACR_CNT == 4
+-        ASM_EXTERN(_psp_saved_acr2)
+-        ASM_EXTERN(_psp_saved_acr3)
+-#endif
+-        ASM_ALIGN(4)
+-
+-ASM_PREFIX(_psp_set_acr):
+-#if PSP_ACR_CNT == 4
+-//#ifndef __ACF__   /* ACF uses register passing */
+-#if PSP_ABI == PSP_ABI_STD
+-   move.l   (4, sp), d0
+-   move.l   (8, sp), d1
+-#endif
+-   cmpi.l   #0, d0
+-
+-   bne.b    l_acr1
+-   movec    d1,acr0
+-   move.l   d1,ASM_PREFIX(_psp_saved_acr0)
+-   rts
+-   ASM_CONST16(0x0000)
+-l_acr1:
+-
+-;   cmpi     #1,d0
+-   cmpi.l   #1,d0
+-
+-   bne.b    l_acr2
+-   movec    d1,acr1
+-   move.l   d1,ASM_PREFIX(_psp_saved_acr1)
+-   rts
+-   ASM_CONST16(0x0000)
+-l_acr2:
+-
+-;   cmpi     #2,d0
+-   cmpi.l   #2,d0
+-
+-   bne.b    l_acr3
+-   movec    d1,acr2
+-   move.l   d1,ASM_PREFIX(_psp_saved_acr2)
+-   rts
+-   ASM_CONST16(0x0000)
+-l_acr3:
+-   movec    d1,acr3
+-   move.l   d1,ASM_PREFIX(_psp_saved_acr3)
+-   rts
+-   ASM_CONST16(0x0000)
+-#else // PSP_ACR_CNT == 4
+-//#ifndef __ACF__   /* ACF uses register passing */
+-#if PSP_ABI == PSP_ABI_STD
+-   move.l   (4, sp), d0
+-   move.l   (8, sp), d1
+-#endif
+-   cmpi.l   #0,d0
+-
+-   bne.b    l_acr1
+-   movec    d1,acr0
+-   move.l   d1,(ASM_PREFIX(_psp_saved_acr0))
+-   rts
+-   ASM_CONST16(0x0000)
+-l_acr1:
+-   movec    d1,acr1
+-   move.l   d1,(ASM_PREFIX(_psp_saved_acr1))
+-   rts
+-   ASM_CONST16(0x0000)
+-#endif // PSP_ACR_CNT == 4
+-
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _psp_get_acr
+-; Returned Value   : uint32_t
+-; Comments         :
+-;   This function gets the specified acr register
+-;
+-;END*----------------------------------------------------------------------
+-
+-        ASM_PUBLIC(_psp_get_acr)
+-        ASM_EXTERN(_psp_saved_acr0)
+-        ASM_EXTERN(_psp_saved_acr1)
+-
+-#if PSP_ACR_CNT == 4
+-        ASM_EXTERN(_psp_saved_acr2)
+-        ASM_EXTERN(_psp_saved_acr3)
+-#endif
+-        ASM_ALIGN(4)
+-
+-ASM_PREFIX(_psp_get_acr):
+-
+-#if PSP_ACR_CNT == 4
+-//#ifndef __ACF__   /* ACF uses register passing */
+-#if PSP_ABI == PSP_ABI_STD
+-   move.l   (4,sp),d0
+-#endif
+-   cmpi.l   #0,d0
+-
+-   bne.b    gl_acr1
+-   move.l   (ASM_PREFIX(_psp_saved_acr0)),d0
+-   rts
+-   ASM_CONST16(0x0000)
+-gl_acr1:
+-
+-;   cmpi     #1,d0
+-   cmpi.l   #1,d0
+-
+-   bne.b    gl_acr2
+-   move.l   (ASM_PREFIX(_psp_saved_acr1)),d0
+-   rts
+-   ASM_CONST16(0x0000)
+-gl_acr2:
+-
+-;   cmpi     #2,d0
+-   cmpi.l   #2,d0
+-
+-   bne.b    gl_acr3
+-   move.l   ASM_PREFIX(_psp_saved_acr2), d0
+-   rts
+-   ASM_CONST16(0x0000)
+-gl_acr3:
+-   move.l   ASM_PREFIX(_psp_saved_acr3), d0
+-   rts
+-   ASM_CONST16(0x0000)
+-#else // PSP_ACR_CNT == 4
+-//#ifndef __ACF__   /* ACF uses register passing */
+-#if PSP_ABI == PSP_ABI_STD
+-   move.l   (4,sp),d0
+-#endif
+-;   cmpi     #0,d0
+-   cmpi.l   #0,d0
+-
+-   bne.b    gl_acr1
+-   move.l   (ASM_PREFIX(_psp_saved_acr0)),d0
+-   rts
+-   ASM_CONST16(0x0000)
+-gl_acr1:
+-   move.l (ASM_PREFIX(_psp_saved_acr1)),d0
+-   rts
+-   ASM_CONST16(0x0000)
+-#endif // PSP_ACR_CNT == 4
+-
+-#endif // PSP_ACR_CNT
+-
+-;ISR*-----------------------------------------------------------------------
+-;
+-; Function Name    : _int_kernel_isr()
+-; Comments         :
+-;   This is the assembler level interrupt isr that intercepts all
+-; interrupts. (When installed on a particular vector).
+-;
+-;   Enough registers are saved so that a 'C' isr can be called.
+-;   If the current stack is not the interrupt stack, then the stack is
+-;   switched over.
+-;
+-;   0 is pushed onto the stack, and a LINK A6 is done.
+-;   This effectively is what a function call does, BUT the return address is 0.
+-;   This will allow a 'C'function to walk back on the stack to find where this
+-;   'interrupt frame' exists.
+-;
+-;   An interrupt 'context' is created on the stack, thus allowing for proper
+-;   operation of MQX 'C' functions that access the error code and _int_enable
+-;   and _int_disable
+-;
+-;   Then interrupt handlers are checked for.  If they have not been installed,
+-;   or the current ISR number is out the range of installed handlers,
+-;   the DEFAULT_ISR is called.
+-;
+-;   If they have been installed then if a user 'C' hander has not been installed
+-;   for this vector, the DEFAULT_ISR is called.
+-;
+-;   After returning from the call to the 'C' isr the following is checked:
+-;   If this is a nested ISR, then we do an interrupt return.
+-;   If the current task is still the highest priority running task, we
+-;   do an interrupt return.
+-;   Otherwise we must save the full context for the current task, and
+-;   enter the scheduler.
+-;
+-;END*------------------------------------------------------------------------
+-
+-        ASM_PUBLIC(_int_kernel_isr)
+-        ASM_PUBLIC(_int_kernel_isr_return_internal)
+-        ASM_ALIGN(4)
+-
+-_isr_save_extra_registers:
+-        SAVE_REST_ISR_REGISTERS
+-        bra.w   _isr_no_save_extra
+-
+-ASM_PREFIX(_int_kernel_isr):
+-        move.l  d0,-(sp)                     ; save D0
+-        move.w  sr,d0                        ; remember SR value
+-        move.w  #0x2700,sr                    ; set level to full disable
+-
+-        SAVE_ISR_REGISTERS                   ; save the registers
+-
+-        GET_KERNEL_DATA a0                   ; get the kernel data address
+-
+-#if MQX_GUERRILLA_INTERRUPTS_EXIST
+-
+-;        move.w  KD_DISABLE_SR(a0),sr         ; reset to correct disable level
+-         move.w  KD_DISABLE_SR(a0),d1         ; reset to correct disable level
+-         move.w  d1,sr                        ;
+-
+-#endif
+-
+-        ; save other registers if exception_isr is installed
+-        clr.l   d1
+-        btst.b  d1,(KD_FLAGS+1,a0)            ; check for bit0 of 16 bit #
+-        bne.w   _isr_save_extra_registers
+-_isr_no_save_extra:
+-        move.w  (FLINT_FORMAT_OFFSET,sp),d1   ; get format and vector offset
+-        andi.l  #0x3fc,d1                     ; get vector number
+-        lsr.l   #2,d1
+-
+-        move.w  (KD_IN_ISR,a0),d2             ; Check for swap to int stack
+-;        tst.w   KD_IN_ISR(a0)                ; Check for swap to int stack
+-        bne.b   _isr_no_stack_swap
+-
+-        movea.l (KD_ACTIVE_PTR,a0),a1         ; Get TD pointer
+-        move.l  sp,(TD_STACK_PTR,a1)          ; and save the stack pointer
+-
+-#if PSP_HAS_DSP
+-        movea.l d1,a2                        ; save d1
+-        SAVE_DSP_REGISTERS a1,a0             ; wipes d1
+-        GET_KERNEL_DATA a0                   ; get the kernel data address
+-        move.l  a2,d1                        ; restore d1
+-#endif
+-
+-        movea.l  (KD_INTERRUPT_STACK_PTR,a0),sp
+-
+-_isr_no_stack_swap:
+-;        move.w  KD_IN_ISR(a0),d2             ; Indicate that ISR running
+-        addq.l  #1,d2
+-        move.w  d2,(KD_IN_ISR,a0)
+-
+-        subq.l  #IC_STRUCT_SIZE-8,sp         ; create interrupt context
+-        subq.l  #8,sp
+-
+-        ; Initialize the interrupt "context"
+-        clr.l   (sp)                         ; Clear the error code
+-        move.w  d0,(4,sp)                     ; save SR as ENABLE sr
+-        move.w  d1,(6,sp)                     ; save interrupt # in context
+-        move.l  (KD_INTERRUPT_CONTEXT_PTR,a0),(IC_PREV_CONTEXT,sp) ; set isr cntxt
+-        move.l  sp,(KD_INTERRUPT_CONTEXT_PTR,a0) ; store new context pointer
+-
+-#if MQX_KERNEL_LOGGING
+-        btst.b  #0,(KD_LOG_CONTROL+3,a0)
+-        beq.b   _isr_no_logging
+-        lea      (-4*6,sp),sp                ; make room on the stack
+-        movem.l d0/d1/d2/a0/a1/a2,(0,sp)     ; save registers used
+-
+-    //#ifdef __ACF__
+-    #if PSP_ABI == PSP_ABI_REG
+-        move.l  d1,d0
+-    #else
+-        move.l  d1,-(sp)                    ; Interrupt number
+-    #endif
+-
+-        jsr     (ASM_PREFIX(_klog_isr_start_internal)).L
+-
+-    //#ifdef __ACF__
+-    #if PSP_ABI == PSP_ABI_REG
+-       movem.l (0,sp),d0/d1/d2/a0/a1/a2     ; restore scratch registers
+-       adda.l  #6*4,sp
+-    #else
+-        movem.l (4,sp),d0/d1/d2/a0/a1/a2     ; restore scratch registers
+-        adda.l  #7*4,sp
+-    #endif
+-
+-_isr_no_logging:
+-#endif // MQX_KERNEL_LOGGING
+-
+-        move.w  d0,sr                        ; Lower to running sr level
+-
+-#if MQX_SPARSE_ISR_TABLE
+-;       Find the 'C' isr to run:
+-        clr.l   d0
+-        move.l  d1, d2
+-        move.w  (KD_LAST_USER_ISR_VECTOR + 2, a0), d0
+-        beq.w   _isr_run_default             ; int table not installed
+-        cmp.l   d0, d1                        ; vector # too high??
+-        bgt.w   _isr_run_default             ; cmp calcs d0-d1 > 0 is bad
+-        move.w  (KD_FIRST_USER_ISR_VECTOR + 2, a0), d0
+-        sub.l   d0, d1                        ; vector # too low??
+-        bge.b   _int_kernel_isr_vect_ok     ; cmp calcs d0-d1 < 0 is bad
+-        bra.w   _isr_run_default
+-
+-;       we have the interrupt # relative to start of interrupt table
+-;       Each table entry is 12 bytes in size, so to get to the correct
+-;       int entry we have to multiply d1 by 12..
+-_int_kernel_isr_vect_ok:
+-
+-        lsr.l   #MQX_SPARSE_ISR_SHIFT, d1
+-
+-        mulu.w  #4,d1
+-
+-        movea.l (KD_INTERRUPT_TABLE_PTR, a0), a1  ; get the interrupt table pointer
+-        adda.l  d1, a1                          ; get address of entry in table - to linked list
+-
+-        movea.l (a1), a1                         ; get address of first isr in linked list
+-        tst.l   a1
+-        beq.w   _isr_run_default                ; isr not used
+-
+-_isr_search:
+-
+-        move.l  (HASH_ISR_NUM, a1), d0            ; get isr num
+-        tst.l   d0
+-        beq.w   _isr_search_fail
+-
+-        cmp.l   d0, d2
+-        beq.w   _isr_search_suc
+-
+-        movea.l (HASH_ISR_NEXT, a1), a1           ; next vector in list
+-        tst.l   a1
+-        bne.w   _isr_search
+-
+-
+-_isr_search_fail:
+-        bra     _isr_run_default
+-_isr_search_suc:
+-
+-//#ifdef  __ACF__
+-#if PSP_ABI == PSP_ABI_REG
+-        movea.l (HASH_ISR_DATA, a1), a0        ; IAR reg convention
+-#else
+-        move.l  (HASH_ISR_DATA, a1), -(sp)     ; push notifier data
+-#endif
+-
+-
+-        movea.l (HASH_ISR_ADDR, a1), a1               ; get ISR handler
+-
+-#else
+-;       Find the 'C' isr to run:
+-        clr.l   d0
+-        move.w  (KD_LAST_USER_ISR_VECTOR+2,a0),d0
+-        beq.w   _isr_run_default             ; int table not installed
+-        cmp.l   d0,d1                        ; vector # too high??
+-        bgt.w   _isr_run_default             ; cmp calcs d0-d1 > 0 is bad
+-        move.w  (KD_FIRST_USER_ISR_VECTOR+2,a0),d0
+-        sub.l   d0,d1                        ; vector # too low??
+-        bge.b   _int_kernel_isr_vect_ok     ; cmp calcs d0-d1 < 0 is bad
+-        bra.w   _isr_run_default
+-
+-;       we have the interrupt # relative to start of interrupt table
+-;       Each table entry is 12 bytes in size, so to get to the correct
+-;       int entry we have to multiply d1 by 12..
+-_int_kernel_isr_vect_ok:
+-        move.w  d1,d0
+-        mulu.w  #12,d0                        ; d0 is now 3*4 * int #
+-
+-        movea.l (KD_INTERRUPT_TABLE_PTR,a0),a1 ; get the interrupt table pointer
+-        adda.l  d0,a1                         ; get address of entry in table
+-//#ifdef  __ACF__
+-#if PSP_ABI == PSP_ABI_REG
+-        movea.l (IT_APP_ISR_DATA,a1), a0        ; IAR reg convention
+-#else
+-        move.l  (IT_APP_ISR_DATA,a1), -(sp)     ; push notifier data
+-#endif
+-
+-        movea.l (IT_APP_ISR,a1),a1             ; get ISR handler
+-#endif
+-
+-_isr_execute:
+-        jsr     (a1)                         ; transfer to 'C' isr
+-#if PSP_ABI == PSP_ABI_STD
+-        adda.l  #4,sp                        ; get rid of  'C' isr parameter
+-#endif
+-
+-ASM_PREFIX(_int_kernel_isr_return_internal):
+-        GET_KERNEL_DATA a0                   ; get kernel data addres
+-        move.w  (KD_DISABLE_SR,a0),d1         ; set level to kernel disable
+-        move.w  d1,sr                        ; set level to kernel disable
+-
+-#if MQX_KERNEL_LOGGING
+-        btst.b  #0,(KD_LOG_CONTROL+3,a0)
+-        beq.b   no_logging4
+-        clr.l   d1
+-        move.w  (6,sp),d1                     ; get interrupt #
+-        lea     (-6*4,sp),sp                 ; make room on the stack
+-        movem.l d0/d1/d2/a0/a1/a2,(0,sp)      ; save registers used
+-
+-     #if PSP_ABI == PSP_ABI_REG
+-        move.l  d1,d0
+-     #else
+-        move.l  d1,-(sp)                     ; Interrupt number
+-     #endif
+-        jsr     (ASM_PREFIX(_klog_isr_end_internal)).L
+-
+-     #if PSP_ABI == PSP_ABI_REG
+-        movem.l (0,sp),d0/d1/d2/a0/a1/a2      ; restore scratch registers
+-        adda.l  #6*4,sp
+-     #else
+-        movem.l (4,sp),d0/d1/d2/a0/a1/a2      ; restore scratch registers
+-        adda.l  #7*4,sp
+-     #endif
+-no_logging4:
+-#endif
+-
+-        move.l  (IC_PREV_CONTEXT,sp),(KD_INTERRUPT_CONTEXT_PTR,a0) ; get previous ISR context
+-        addq.l  #IC_STRUCT_SIZE-8,sp         ; remove the interrupt context
+-        addq.l  #8,sp                        ;
+-
+-        clr.l   d0
+-        move.w  (KD_IN_ISR,a0),d0             ; out of 1 ISR
+-        subq.l   #1,d0
+-        move.w  d0,(KD_IN_ISR,a0)
+-        bne.w   _isr_nested_interrupt
+-
+-;       Completed all nested interrupts
+-        movea.l (KD_ACTIVE_PTR,a0),a1         ; Get TD pointer
+-        movea.l (TD_STACK_PTR,a1),sp          ; Return to old stack
+-
+-;       Check SR value on stack for HW nested stack frames
+-        clr.l   d0
+-        clr.l   d1
+-        move.b  (FLINT_SR_OFFSET,sp),d0
+-        andi.l  #0x27,d0
+-        move.b  (KD_ACTIVE_SR,a0),d1          ; Just check lower 3 bits!!
+-        cmp.l   d1,d0
+-        bne.b   _isr_nested_interrupt
+-
+-;       Check to see if reschedule necessary
+-        move.w  (TD_FLAGS+2,a1),d0
+-        andi.l  #PREEMPTION_DISABLED,d0
+-        bne.b   _isr_nested_interrupt        ; task has preemption disabled
+-
+-;        If a different TD at head of current readyq, then we need to run
+-;        the scheduler
+-        move.l  a1,d0
+-        movea.l (KD_CURRENT_READY_Q,a0),a1
+-        cmp.l   (a1),d0
+-        bne.w   _isr_context_switch          ; diffent td at head of readyq
+-
+-        movea.l (KD_ACTIVE_PTR,a0),a1         ; Get TD pointer
+-#if PSP_HAS_DSP
+-        RESTORE_DSP_REGISTERS a1,a2          ; kills d0
+-#endif
+-
+-        ; save other registers if exception_isr is installed
+-        clr.l   d0
+-        btst.b  d0,(KD_FLAGS + 1, a0)            ; check for bit0 of 16 bit #
+-        bne.b   _isr_restore_extra
+-        RESTORE_ISR_REGISTERS
+-        rte
+-        ASM_CONST16(0x0000)
+-
+-_isr_nested_interrupt:
+-        movea.l (KD_ACTIVE_PTR,a0),a1         ; Get TD pointer
+-
+-        ; save other registers if exception_isr is installed
+-        clr.l   d0
+-        btst.b  d0,(KD_FLAGS+1,a0)            ; check for bit0 of 16 bit #
+-        bne.b   _isr_restore_extra
+-        RESTORE_ISR_REGISTERS
+-        rte
+-        ASM_CONST16(0x0000)
+-
+-_isr_restore_extra:                          ; restore extra registers
+-        RESTORE_REST_ISR_REGISTERS
+-        rte
+-        ASM_CONST16(0x0000)
+-
+-_isr_run_default:
+-        clr.l   d1
+-        move.w  (6,sp),d1                     ; get interrupt # in context
+-
+-#if PSP_ABI == PSP_ABI_REG
+-        move.l  d1,d0
+-#else
+-        move.l  d1,-(sp)                     ; d1 has vector #
+-#endif
+-
+-        movea.l (KD_DEFAULT_ISR,a0),a1
+-        bra.w   _isr_execute
+-
+-_isr_context_switch:
+-        ; No need to save other registers if exception_isr is installed
+-        clr.l   d0
+-        btst.b  d0,(KD_FLAGS+1,a0)            ; check for bit0 of 16 bit #
+-        bne.b   _isr_no_save_extra_again
+-        SAVE_REST_ISR_REGISTERS
+-_isr_no_save_extra_again:
+-        GET_KERNEL_DATA a2
+-        bra.w   __sched_internal
+-
+-; Do not include the cache code if the CPU has no cache
+-#if PSP_HAS_CODE_CACHE || PSP_HAS_DATA_CACHE
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _icache_invalidate_mlines
+-; Returned Value   :
+-; Comments         :
+-;   This function invalidate m lines from instruction cache
+-;
+-;END*----------------------------------------------------------------------
+-
+-        ASM_PUBLIC(_icache_invalidate_mlines)
+-ASM_PREFIX(_icache_invalidate_mlines):
+-        link     a6,#0
+-
+-#if PSP_ABI == PSP_ABI_STD
+-        movea.l  8(a6),a1       ; Base address to begin invalidating
+-        move.l   12(a6),d2      ; Number of lines to invalidate
+-        move.l   16(a6),d1      ; Size of one cache line
+-#else
+-        move.l  a0, a1
+-        move.l  d0, d2
+-#endif
+-
+-        moveq    #0,d0          ; for (d0 = 0; d0 < mlines; d0++)
+-        bra.s    test_mlines
+-invalidate_another_line:
+-
+-#if PSP_CACHE_SPLIT
+-;        ASM_CONST16(0xF4A9)      ; cpushl ic,(a1)
+-        cpushl  ic, (a1)
+-#else
+-;       ASM_CONST16(0xF4E9)         ; cpushl bc,(a1)
+-        cpushl  bc, (a1)
+-#endif
+-
+-        adda.l   d1,a1
+-        addq.l   #1,d0
+-test_mlines:
+-        cmp.l    d2,d0
+-        bcs.s    invalidate_another_line
+-        unlk     a6
+-        rts
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _dcache_flush_mlines
+-; Returned Value   :
+-; Comments         :
+-;   This function flush data cache m lines
+-;
+-;END*----------------------------------------------------------------------
+-
+-#if 0
+-        ASM_PUBLIC(_dcache_flush_mlines)
+-ASM_PREFIX(_dcache_flush_mlines):
+-        link     a6,#0
+-
+-#if PSP_ABI == PSP_ABI_STD
+-        movea.l  (8,a6),a1       ; Base address to begin invalidating
+-        move.l   (12,a6),d2      ; Number of lines to flush
+-        move.l   (16,a6),d1      ; Size of one cache line
+-#else
+-        move.l  a0, a1
+-        move.l  d0, d2
+-#endif
+-
+-        moveq    #0,d0          ; for (d0 = 0; d0 < mlines; d0++)
+-        bra.s    (test_flush_mlines)
+-flush_another_line:
+-
+-#if PSP_CACHE_SPLIT
+-;        ASM_CONST16(0xF469)    ; cpushl dc,(a1)
+-        cpushl dc, (a1)
+-#else
+-;        ASM_CONST16(0xF4E9)    ; cpushl bc,(a1)
+-        cpushl bc, (a1)
+-#endif
+-
+-        adda.l   d1,a1
+-        addq.l   #1,d0
+-test_flush_mlines:
+-        cmp.l    d2,d0
+-        bcs.s    flush_another_line
+-        unlk     a6
+-        rts
+-#endif
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _psp_dcache_flush_all
+-; Comments         :
+-;    This function will flush the entire data cache.
+-;
+-;END*------------------------------------------------------------------------
+-        ASM_PUBLIC(_psp_dcache_flush_all)
+-ASM_PREFIX(_psp_dcache_flush_all):
+-    link     a6,#0
+-
+-#if PSP_ABI == PSP_ABI_STD
+-    lea      -16(a7),a7         ;Allocate frame to store D3,D4,D5
+-    movem.l  d3-d5,4(a7)        ;Cannot trash D3,D4,D5
+-    move.l    8(a6),d2          ;param1 => int cache_line_size
+-    move.l   12(a6),d3          ;param2 => int num_ways
+-    move.l   16(a6),d4          ;param3 => int num_sets
+-#else
+-    lea      -16(a7),a7         ;Allocate frame to store D3,D4,D5
+-    movem.l  d3-d5, 4(a7)        ;Cannot trash D3,D4,D5
+-
+-    move.l  d2, d4
+-    move.l  d1, d3
+-    move.l  d0, d2
+-#endif
+-
+-    nop                         ;synchronize/flush store buffer
+-
+-    move.w   sr,d5              ;** Disable interrupts
+-    move.l   #0x2700,d0         ;Cannot have the data cache changing
+-    move.w   d0,sr
+-
+-    moveq.l  #0,d0              ;initialize way counter
+-    moveq.l  #0,d1              ;initialize set counter
+-    move.l   d0,a0              ;initialize cpushl pointer
+-setloop:
+-#if PSP_CACHE_SPLIT
+-    cpushl   dc, (a0)           ;push cache line a0
+-#else
+-    cpushl   bc, (a0)           ;push cache line a0
+-#endif
+-
+-    add.l    d2,a0              ;increment set index by 1
+-    addq.l   #1,d1              ;increment set counter
+-    cmp.l    d4,d1              ;are sets for this way done?
+-    blt      setloop
+-    moveq.l  #0,d1              ;set counter to zero again
+-    addq.l   #1,d0              ;increment to next way
+-    move.l   d0,a0              ;set = 0, way = d0
+-    cmp.l    d3,d0              ;flushed all the ways?
+-    blt      setloop
+-
+-    move.w   d5,sr              ;** Re-enable interrupts
+-    movem.l  4(a7),d3-d5
+-    unlk     a6
+-    rts
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _dcache_flush
+-; Comments         :
+-;    This function will flush the data cache
+-;
+-;END*------------------------------------------------------------------------
+-        ASM_PUBLIC(_dcache_flush)
+-ASM_PREFIX(_dcache_flush):
+-
+-#if PSP_ABI == PSP_ABI_STD
+-        movea.l (4, sp), a0         ; start address
+-        move.l  (8, sp), d0         ; line cnt
+-        move.l  (12, sp), d1        ; cache_line_size
+-#endif
+-
+-        move.w  sr, d2              ; disable interrupts
+-        ;lea     -8(sp), sp          ; allocate frame to store SR
+-        move.l  d2, -(sp)
+-
+-        move.l  #0x2700, d2         ;Cannot have the data cache changing
+-        move.w  d2, sr
+-
+-
+-        move.l  a0, d2
+-        and.l   #0xfffffff0, d2
+-        movea.l d2, a0
+-
+-        moveq   #0, d2              ; for (d2 = 0; d2 < mlines (d0); d2++)
+-        bra.s   dcache_flush_test
+-
+-dcache_flush_line:
+-        movea.l a0, a1
+-
+-        // TODO add support for split cache
+-#if PSP_CACHE_SPLIT
+-        cpushl  dc, (a1)
+-
+-        adda.l  #1, a1
+-        cpushl  dc, (a1)
+-
+-        adda.l  #1, a1
+-        cpushl  dc, (a1)
+-
+-        adda.l  #1, a1
+-        cpushl  dc, (a1)
+-#else
+-        cpushl  bc, (a1)
+-
+-        adda.l  #1, a1
+-        cpushl  bc, (a1)
+-
+-        adda.l  #1, a1
+-        cpushl  bc, (a1)
+-
+-        adda.l  #1, a1
+-        cpushl  bc, (a1)
+-#endif
+-
+-        adda.l  d1, a0
+-        addq.l  #1, d2
+-dcache_flush_test:
+-        cmp.l   d0, d2
+-        bcs.s   dcache_flush_line
+-
+-        move.l (sp)+, d2
+-        move.w  d2, sr              ; enable interrupts
+-
+-        rts
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : _dcache_flush_phy
+-; Returned Value   :
+-; Comments         :
+-;   This function flush data cache by physical address (mcf54455 feature)
+-;
+-;END*----------------------------------------------------------------------
+-
+-        ASM_PUBLIC(_dcache_flush_phy)
+-ASM_PREFIX(_dcache_flush_phy):
+-
+-#if PSP_ABI == PSP_ABI_STD
+-        movea.l (4, sp), a0         ; Base address to begin invalidating
+-        move.l  (8, sp), d0         ; Number of lines to flush
+-        move.l  (12, sp), d1        ; Size of one cache line
+-#endif
+-
+-        moveq   #0, d2              ; for (d2 = 0; d2 < mlines (d0); d2++)
+-        bra.s   dcache_flush_phy_test
+-
+-dcache_flush_phy_line:
+-        cpushl  dc, (a0)
+-
+-        adda.l  d1, a0
+-        addq.l  #1, d2
+-dcache_flush_phy_test:
+-        cmp.l   d0, d2
+-        bcs.s   dcache_flush_phy_line
+-
+-        rts
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : __psp_enable_acrs
+-; Returned Value   :
+-; Comments         :
+-;   This function enable ACR registers
+-;
+-;END*----------------------------------------------------------------------
+-
+-        ASM_PUBLIC(__psp_enable_acrs)
+-ASM_PREFIX(__psp_enable_acrs):
+-    link     a6,#0
+-#if PSP_ABI == PSP_ABI_STD
+-    movea.l  (8,a6),a1           ; [IN] int ACR_VAL[4] param
+-#else
+-    movea.l     a0, a1
+-#endif
+-
+-
+-    move.l   (a1),d0
+-    movec    d0,acr0
+-    move.l   4(a1),d0
+-    movec    d0,acr1
+- #if PSP_ACR_CNT == 4
+-    move.l   8(a1),d0
+-    movec    d0,acr2
+-    move.l   12(a1),d0
+-    movec    d0,acr3
+- #endif // PSP_ACR_CNT == 4
+-    nop                         ; Sync pipeline
+-    unlk     a6
+-    rts
+-
+-;FUNCTION*-------------------------------------------------------------------
+-;
+-; Function Name    : __psp_clear_acrs
+-; Returned Value   :
+-; Comments         :
+-;   This function clear ACR registers
+-;
+-;END*----------------------------------------------------------------------
+-
+-        ASM_PUBLIC(__psp_clear_acrs)
+-ASM_PREFIX(__psp_clear_acrs):
+-    moveq.l  #0,d0
+-    movec    d0,ACR0
+-    movec    d0,ACR1
+-
+-#if PSP_ACR_CNT == 4
+-    movec    d0,ACR2
+-    movec    d0,ACR3
+-#endif // PSP_ACR_CNT == 4
+-
+-    nop                         ; Sync pipeline
+-    rts
+-
+-#endif
+-
++|*HEADER********************************************************************
++|*
++|* Copyright 2008 Freescale Semiconductor, Inc.
++|* Copyright 1989-2008 ARC International
++|*
++|* This software is owned or controlled by Freescale Semiconductor.
++|* Use of this software is governed by the Freescale MQX RTOS License
++|* distributed with this Material.
++|* See the MQX_RTOS_LICENSE file distributed for more details.
++|*
++|* Brief License Summary:
++|* This software is provided in source form for you to use free of charge,
++|* but it is not open source software. You are allowed to use this software
++|* but you cannot redistribute it or derivative works of it in source form.
++|* The software may be used only in connection with a product containing
++|* a Freescale microprocessor, microcontroller, or digital signal processor.
++|* See license agreement file for full license terms including other restrictions.
++|**************************************************************************
++|*
++|* Comments:
++|*
++|*   This assembler file contains functions for task scheduling
++|*
++|*END***********************************************************************
++
++        |.file "dispatch.s"
++
++#include <asm_mac.h>
++#include "mqx_cnfg.h"
++
++#define __ASM__
++#include "psp.h"
++#undef __ASM__
++
++#include "types.inc"
++#include "psp_prv.inc"
++
++#ifdef __ACF__
++        RSEG KERNEL:CODE (4)
 +#else
 +#if defined(__GNUC__) && !defined(__CWCC__)
 +        .section .text
 +        .section KERNEL, "ax"
- #else
-         .text
-         .section KERNEL,16,x
- #endif
++
++        | ColdFire MOVEC control-register selectors.
++        | GAS's m68k register-name table only recognizes CACR/ACRn/MBAR
++        | mnemonics for classic 68020/030/040/060 CPUs, not for ColdFire
++        | targets; on ColdFire these must be written as movec Rn,#<selector>.
++        | Selector values match the Freescale/IAR numeric constants (see
++        | mqx/source/psp/coldfire/types.inc, __ACF__ block).
++        .equ    CF_CACR, 0x002
++        .equ    CF_ACR0, 0x004
++        .equ    CF_ACR1, 0x005
++        .equ    CF_ACR2, 0x006
++        .equ    CF_ACR3, 0x007
++        .equ    CF_MBAR, 0x008
++#else
++        .text
++        .section KERNEL,16,x
 +#endif
- 
- ;FUNCTION*-------------------------------------------------------------------
- ;
++#endif
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _task_block
++| Comments         :
++| This function is called by a task to save its context and remove
++| itself from its ready queue. The next runnable task in the ready queues
++| is made active and dispatched.  The state of the task is marked as being
++| blocked.
++|
++|END*------------------------------------------------------------------------
++
++        ASM_PUBLIC(_task_block)
++        ASM_ALIGN(4)
++
++ASM_PREFIX(_task_block):
++        SAVE_ALL_REGISTERS              | Save the context of the active task.
++
++        GET_KERNEL_DATA a2              | Get the address of kernel data
++        movea.l (KD_ACTIVE_PTR,a2),a3    | get active td
++        move.w  (KD_DISABLE_SR,a2),d0    | DISABLE INTERRUPTS
++        move.w  d0,sr
++        move.l  sp,(TD_STACK_PTR,a3)     | save stack pointer
++#if PSP_HAS_DSP
++        SAVE_DSP_REGISTERS a3,a4        | wipes d1
++#endif
++        moveq.l #1,d0                   | Set the block bit
++        or.l    d0,(TD_STATE,a3)
++
++#if MQX_KERNEL_LOGGING
++        KLOG    a2,ASM_PREFIX(_klog_block_internal) | kernel log this function
++#endif
++
++|       Remove the active task from the ready queue.
++        movea.l (TD_TD_PREV,a3),a1       | get ptr to ready_q structure
++        movea.l (TD_TD_NEXT,a3),a4
++        move.l  a4,(RQ_HEAD_READY_Q,a1)
++        move.l  a1,(TD_TD_PREV,a4)
++
++        bra.w   __sched_internal  | Search for the next task in the ready queue.
++
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _sched_start_internal
++| Comments         :
++|  This function is called from _mqx in order to start the task
++|  scheduler running.
++|
++|END*------------------------------------------------------------------------
++
++        ASM_PUBLIC(_sched_start_internal)
++        ASM_ALIGN(4)
++
++ASM_PREFIX(_sched_start_internal):
++        GET_KERNEL_DATA a2
++        bra.w           __sched_internal
++
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _sched_check_scheduler_internal
++| Comments         :
++|    This function is called to check whether scheduling is necessary
++| It falls through into the next function
++|
++| Function Name    : _sched_execute_scheduler_internal
++| Comments         :
++|    This function is called by a task to save its context.
++| This is usually done when the task has already been removed from the
++| ready queue, and is on some other queue.
++| However it can also be called so that the current tasks context is saved
++| so that the scheduler can run (in case of a higher priority task being
++| available.
++|
++| It falls through to the next function
++|
++| Function Name    : _sched_internal
++| Comments         :
++|   This function is the actual task scheduler... IT IS NOT CALLABLE from C
++| rather, other assembler functions in this file jump to it.
++|
++|END*------------------------------------------------------------------------
++
++        ASM_PUBLIC(_sched_check_scheduler_internal)
++        ASM_PUBLIC(_sched_execute_scheduler_internal)
++        ASM_PUBLIC(__sched_context_switch_internal)
++        ASM_PUBLIC(_sched_run_internal)
++ASM_PREFIX(_sched_run_internal):
++        GET_KERNEL_DATA a2              | Get address of kernel data
++        bra.w    __sched_internal
++
++__sched_check_return:
++        rts
++        ASM_CONST16(0x0000)
++
++
++        ASM_ALIGN(4)
++ASM_PREFIX(_sched_check_scheduler_internal):
++|       Use A0, D0: both scratch registers
++        GET_KERNEL_DATA a0              | Get address of kernel data
++        move.w  (KD_IN_ISR,a0),d0
++        bne.b   __sched_check_return    | We are in an ISR, so return
++        move.l  (KD_CURRENT_READY_Q,a0),d0
++        movea.l (KD_ACTIVE_PTR,a0),a0
++        cmp.l   (TD_MY_QUEUE,a0),d0
++        beq.b   __sched_check_return    | Current task is still the active task
++
++ASM_PREFIX(_sched_execute_scheduler_internal):
++        SAVE_ALL_REGISTERS              | Save the context of the active task.
++
++        GET_KERNEL_DATA a2              | Get address of kernel data
++        movea.l (KD_ACTIVE_PTR,a2),a3    | get active td
++        move.w  (KD_DISABLE_SR,a2),d0    | DISABLE INTERRUPTS
++        move.w  d0,sr
++        move.l  sp,(TD_STACK_PTR,a3)     | save stack pointer
++#if PSP_HAS_DSP
++        SAVE_DSP_REGISTERS a3,a4        | wipes d1
++#endif
++
++#if MQX_KERNEL_LOGGING
++        KLOG    a2,ASM_PREFIX(_klog_execute_scheduler_internal) | kernel log this function
++#endif
++
++|
++|  MAIN TASK SCHEDULER CODE
++|  Arrive here from other assembler functions with a2 already set
++
++__sched_internal:
++        move.w  (KD_DISABLE_SR,a2),d0    | DISABLE INTERRUPTS
++        move.w  d0,sr
++        movea.l (KD_CURRENT_READY_Q,a2),a1  | get current ready q
++
++find_nonempty_queue:
++        movea.l (a1),a3                 | address of first td
++        cmpa.l  a3,a1                   | ready_q structure itself?
++        bne.b   activate
++        movea.l (RQ_NEXT_Q,a1),a1        | try next queue
++        move.l  a1,d0
++        bne.b   find_nonempty_queue
++
++       | No task available to run
++no_one_to_run:
++|       Set up system task running and wait for an interrupt
++        lea.l   (KD_SYSTEM_TD,a2),a3
++        move.l  a3,(KD_ACTIVE_PTR,a2)
++        move.w  #0x2000,d0
++        move.w  d0,(KD_ACTIVE_SR,a2)
++| Start CR 1169
++|       move.l  KD_INTERRUPT_STACK_PTR(a2),sp
++        GET_SYSTEM_STACK a1
++        movea.l a1, sp
++| End CR 1169
++#if PSP_STOP_ON_IDLE
++        stop    #0x2000
++#else
++        move.w  #0x2000,sr
++#endif
++
++
++        movea.l (KD_READY_Q_LIST,a2),a1  | get ready just in case
++        bra.b   find_nonempty_queue
++
++activate:
++#if MQXCFG_ENABLE_FP && PSP_HAS_FPU
++|       We now have the new task to run, check if it needs the
++|       floating point co-processor
++        move.w   (TD_FLAGS+2,a3),d0
++        andi.l   #FP_TASK_MASK,d0
++        bne.b    do_floating_point
++#endif
++
++no_floating_point:
++        move.l   a1,(KD_CURRENT_READY_Q,a2)
++        move.l   a3,(KD_ACTIVE_PTR,a2)
++        move.w   (TD_TASK_SR,a3),(KD_ACTIVE_SR,a2)
++        movea.l  (TD_STACK_PTR,a3),sp     | restore stack pointer
++
++#if MQX_KERNEL_LOGGING
++        KLOG     a2,ASM_PREFIX(_klog_context_switch_internal)  | do kernel logging
++#endif
++
++#if MQX_HAS_CONTEXT_SWITCH_HANDLER
++        move.l  a2, -(sp)
++        jsr     ASM_PREFIX(_mqx_context_switch_internal)
++        move.l  (sp)+, a2
++#endif
++
++#if PSP_HAS_DSP
++        RESTORE_DSP_REGISTERS a3,a0      | kills d0
++#endif
++        RESTORE_ALL_REGISTERS            | restore task context
++__sched_context_switch_internal:
++        rte
++        ASM_CONST16(0x0000)
++
++#if MQXCFG_ENABLE_FP && PSP_HAS_FPU
++        ASM_ALIGN(4)
++do_floating_point:
++|       See if a floating point task is currently active
++        movea.l  (KD_FP_ACTIVE_PTR,a2),a4
++        tst.l    a4
++        beq.b    restore_fp_context
++
++|       See if the floating point task is in fact the task being scheduled
++|       So, no need to save and restore pointers
++        cmpa.l   a3,a4
++        beq.b    no_floating_point
++
++|       Stop the floating point unit, and save the internal
++|       floating point registers in the floating point context
++|       save area allocated for the task
++        movea.l  (TD_FLOAT_CONTEXT_PTR,a4), a0
++        fmove.l  FPSR,(FP_FPSR_OFFSET,a0)
++        fmove.l  FPCR,FP_FPCR_OFFSET(a0)
++        fmove.l  FPIAR,FP_FPIAR_OFFSET(a0)
++        fmovem   FP0-FP7,(FP_FPR0_OFFSET,a0)
++
++|       Indicate in TD that FP context saved
++        move.w   (TD_FLAGS+2,a4),d0
++        or.l     #FP_CONTEXT_SAVED_MASK,d0      | Set the block bit
++        move.w   d0,(TD_FLAGS+2,a4)
++
++restore_fp_context:
++|       Restore the context of the current FP task if necessary
++        move.l   a3,(KD_FP_ACTIVE_PTR,a2)
++        move.w   (TD_FLAGS+2,a3),d0
++        andi.l   #FP_CONTEXT_SAVED_MASK,d0
++        beq.b    no_fp_registers_to_restore
++
++|       Now restore the floating point context
++        movea.l  (TD_FLOAT_CONTEXT_PTR,a3), a0
++
++  #if MQX_FP_CONTEXT_CHECK
++|       This code tests that the floating point buffer we are restoring
++|       the floating point context from really belongs to task 'a3'.  If
++|       the task ID's don't match then something has been corrupted.
++|       This code can be disabled for faster performance.
++        move.l   (TD_TASK_ID,a3),d0
++        cmp.l    (FP_TID_OFFSET,a0),d0
++        beq.b    fp_context_check_ok
++        move.l   #4138,d0
++        move.l   d0,(a7)
++        ASM_EXTERN(ASM_PREFIX(_mqx_fatal_error))
++        jsr (ASM_PREFIX(_mqx_fatal_error))
++        halt
++fp_context_check_ok:
++  #endif
++
++        fmovem   (FP_FPR0_OFFSET,a0),FP0-FP7
++        fmove.l  (FP_FPCR_OFFSET,a0),FPCR
++        fmove.l  (FP_FPIAR_OFFSET,a0),FPIAR
++        fmove.l  (FP_FPSR_OFFSET,a0),FPSR
++
++no_fp_registers_to_restore:
++        move.w   (TD_FLAGS+2,a3),d0
++        and.l    #FP_CONTEXT_CLEAR_MASK,d0
++        move.w   d0,(TD_FLAGS+2,a3)
++        jmp      (no_floating_point)
++#endif
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _psp_save_fp_context_internal
++| Returned Value   : none
++| Comments         :
++|   This function saves the floating point context for the
++| current floating point task
++|
++| THIS FUNCTION MUST BE CALLED DISABLED
++|
++|END*----------------------------------------------------------------------
++
++        ASM_PUBLIC(_psp_save_fp_context_internal)
++        ASM_ALIGN(4)
++
++ASM_PREFIX(_psp_save_fp_context_internal):
++#if MQXCFG_ENABLE_FP && PSP_HAS_FPU
++|       Stop the floating point unit, and save the internal
++|       floating point registers on the stack of the FP task
++        GET_KERNEL_DATA a0
++        movea.l  (KD_FP_ACTIVE_PTR,a0),a0
++        move.w   (TD_FLAGS+2,a0),d0
++        andi.l   #FP_CONTEXT_SAVED_MASK,d0
++        bne.b    _psp_save_fp_context_done
++
++        or.l     #FP_CONTEXT_SAVED_MASK,d0
++        move.w   d0,(TD_FLAGS+2,a0)
++        movea.l  (TD_FLOAT_CONTEXT_PTR,a0), a0
++        fmove.l  FPSR,(FP_FPSR_OFFSET,a0)
++        fmove.l  FPCR,FP_FPCR_OFFSET(a0)
++        fmove.l  FPIAR,FP_FPIAR_OFFSET(a0)
++        fmovem   FP0-FP7,(FP_FPR0_OFFSET,a0)
++#endif
++_psp_save_fp_context_done:
++        rts
++        ASM_CONST16(0x0000)
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _psp_set_a6_sp_and_goto
++| Returned Value   : previous value of location
++| Comments         :
++|   This function tests a byte location, and if 0, sets it to 0x80.
++|   It returns the previous value of the byte.
++|
++|END*----------------------------------------------------------------------
++
++        ASM_PUBLIC(_psp_set_a6_sp_and_goto)
++        ASM_ALIGN(4)
++
++ASM_PREFIX(_psp_set_a6_sp_and_goto):
++//#ifndef __ACF__   /* ACF uses register passing */
++#if PSP_ABI == PSP_ABI_STD
++   movea.l  (4,sp), a6
++   movea.l  (12,sp), a0
++   movea.l  (8,sp), sp
++#else
++   movea.l  d0, a6
++   movea.l  d1, sp
++   movea.l  d2, a0
++#endif
++   jmp      (a0)
++   rts
++   ASM_CONST16(0x0000)
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _mem_test_and_set
++| Returned Value   : previous value of location
++| Comments         :
++|   This function tests a byte location, and if 0, sets it to 0x80.
++|   It returns the previous value of the byte.
++|
++|END*----------------------------------------------------------------------
++
++        ASM_PUBLIC(_mem_test_and_set)
++        ASM_ALIGN(4)
++
++ASM_PREFIX(_mem_test_and_set):
++//#ifndef __ACF__   /* ACF uses register passing */
++#if PSP_ABI == PSP_ABI_STD
++   movea.l (4,sp),a0
++#endif
++   bset.b  #7,(a0)
++   bne.b   bit_was_set
++   clr.l   d0
++   rts
++   ASM_CONST16(0x0000)
++
++bit_was_set:
++   move.l  #0x80,d0
++   rts
++   ASM_CONST16(0x0000)
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _psp_set_sr
++| Returned Value   : none
++| Comments         :
++|   This function sets the sr register
++|
++|END*----------------------------------------------------------------------
++        ASM_PUBLIC(__psp_set_sr)
++        ASM_ALIGN(4)
++
++ASM_PREFIX(__psp_set_sr):
++//#ifndef __ACF__   /* ACF uses register passing */
++#if PSP_ABI == PSP_ABI_STD
++   move.l   (4,sp),d0
++#endif
++   move.w   d0,sr
++   rts
++   ASM_CONST16(0x0000)
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _psp_get_sr
++| Returned Value   : none
++| Comments         :
++|   This function gets the sr register
++|
++|END*----------------------------------------------------------------------
++        ASM_PUBLIC(__psp_get_sr)
++        ASM_ALIGN(4)
++
++ASM_PREFIX(__psp_get_sr):
++   move.w   sr,d0
++   rts
++   ASM_CONST16(0x0000)
++
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _psp_set_vbr
++| Returned Value   : uint32_t vbr value
++| Comments         :
++|   This function sets the vbr register
++|
++|END*----------------------------------------------------------------------
++        ASM_PUBLIC(_psp_set_vbr)
++        ASM_ALIGN(4)
++
++ASM_PREFIX(_psp_set_vbr):
++//#ifndef __ACF__   /* ACF uses register passing */
++#if PSP_ABI == PSP_ABI_STD
++   move.l   (4,sp),d0
++#endif
++   movec    d0, vbr
++   rts
++   ASM_CONST16(0x0000)
++
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _psp_set_cpucr
++| Returned Value   : none
++| Comments         :
++|   This function sets the cpucr register
++|
++|END*----------------------------------------------------------------------
++        ASM_PUBLIC(_psp_set_cpucr)
++        ASM_ALIGN(4)
++
++ASM_PREFIX(_psp_set_cpucr):
++//#ifndef __ACF__   /* ACF uses register passing */
++#if PSP_ABI == PSP_ABI_STD
++   move.l   (4,sp),d0
++#endif
++|   movec    d0,cpucr
++   ASM_CONST16(0x4E7B)
++   ASM_CONST16(0x0802)
++   rts
++   ASM_CONST16(0x0000)
++
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _psp_set_cacr
++| Returned Value   : uint32_t cacr value
++| Comments         :
++|   This function sets the cacr register
++|
++|END*----------------------------------------------------------------------
++        ASM_PUBLIC(_psp_set_cacr)
++        ASM_ALIGN(4)
++
++ASM_PREFIX(_psp_set_cacr):
++#ifdef __ACF__   /* ACF uses register passing */
++   movec    d0, 0x002
++#else
++
++#if PSP_ABI == PSP_ABI_STD
++    move.l   (4,sp),d0
++#endif
++
++    movec    d0, #CF_CACR
++#endif
++   rts
++   ASM_CONST16(0x0000)
++
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _psp_set_mbar
++| Returned Value   : none
++| Comments         :
++|   This function sets the mbar register
++|
++|END*----------------------------------------------------------------------
++        ASM_PUBLIC(_psp_set_mbar)
++        ASM_ALIGN(4)
++
++ASM_PREFIX(_psp_set_mbar):
++//#ifndef __ACF__   /* ACF uses register passing */
++#if PSP_ABI == PSP_ABI_STD
++   move.l   (4,sp),d0
++#endif
++   movec    d0, #CF_MBAR
++   rts
++   ASM_CONST16(0x0000)
++
++
++#if PSP_ACR_CNT
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _psp_set_acr
++| Returned Value   : none
++| Comments         :
++|   This function sets the specified acr register
++|
++|END*----------------------------------------------------------------------
++
++        ASM_PUBLIC(_psp_set_acr)
++        ASM_EXTERN(_psp_saved_acr0)
++        ASM_EXTERN(_psp_saved_acr1)
++
++#if PSP_ACR_CNT == 4
++        ASM_EXTERN(_psp_saved_acr2)
++        ASM_EXTERN(_psp_saved_acr3)
++#endif
++        ASM_ALIGN(4)
++
++ASM_PREFIX(_psp_set_acr):
++#if PSP_ACR_CNT == 4
++//#ifndef __ACF__   /* ACF uses register passing */
++#if PSP_ABI == PSP_ABI_STD
++   move.l   (4, sp), d0
++   move.l   (8, sp), d1
++#endif
++   cmpi.l   #0, d0
++
++   bne.b    l_acr1
++   movec    d1,#CF_ACR0
++   move.l   d1,ASM_PREFIX(_psp_saved_acr0)
++   rts
++   ASM_CONST16(0x0000)
++l_acr1:
++
++|   cmpi     #1,d0
++   cmpi.l   #1,d0
++
++   bne.b    l_acr2
++   movec    d1,#CF_ACR1
++   move.l   d1,ASM_PREFIX(_psp_saved_acr1)
++   rts
++   ASM_CONST16(0x0000)
++l_acr2:
++
++|   cmpi     #2,d0
++   cmpi.l   #2,d0
++
++   bne.b    l_acr3
++   movec    d1,#CF_ACR2
++   move.l   d1,ASM_PREFIX(_psp_saved_acr2)
++   rts
++   ASM_CONST16(0x0000)
++l_acr3:
++   movec    d1,#CF_ACR3
++   move.l   d1,ASM_PREFIX(_psp_saved_acr3)
++   rts
++   ASM_CONST16(0x0000)
++#else // PSP_ACR_CNT == 4
++//#ifndef __ACF__   /* ACF uses register passing */
++#if PSP_ABI == PSP_ABI_STD
++   move.l   (4, sp), d0
++   move.l   (8, sp), d1
++#endif
++   cmpi.l   #0,d0
++
++   bne.b    l_acr1
++   movec    d1,#CF_ACR0
++   move.l   d1,(ASM_PREFIX(_psp_saved_acr0))
++   rts
++   ASM_CONST16(0x0000)
++l_acr1:
++   movec    d1,#CF_ACR1
++   move.l   d1,(ASM_PREFIX(_psp_saved_acr1))
++   rts
++   ASM_CONST16(0x0000)
++#endif // PSP_ACR_CNT == 4
++
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _psp_get_acr
++| Returned Value   : uint32_t
++| Comments         :
++|   This function gets the specified acr register
++|
++|END*----------------------------------------------------------------------
++
++        ASM_PUBLIC(_psp_get_acr)
++        ASM_EXTERN(_psp_saved_acr0)
++        ASM_EXTERN(_psp_saved_acr1)
++
++#if PSP_ACR_CNT == 4
++        ASM_EXTERN(_psp_saved_acr2)
++        ASM_EXTERN(_psp_saved_acr3)
++#endif
++        ASM_ALIGN(4)
++
++ASM_PREFIX(_psp_get_acr):
++
++#if PSP_ACR_CNT == 4
++//#ifndef __ACF__   /* ACF uses register passing */
++#if PSP_ABI == PSP_ABI_STD
++   move.l   (4,sp),d0
++#endif
++   cmpi.l   #0,d0
++
++   bne.b    gl_acr1
++   move.l   (ASM_PREFIX(_psp_saved_acr0)),d0
++   rts
++   ASM_CONST16(0x0000)
++gl_acr1:
++
++|   cmpi     #1,d0
++   cmpi.l   #1,d0
++
++   bne.b    gl_acr2
++   move.l   (ASM_PREFIX(_psp_saved_acr1)),d0
++   rts
++   ASM_CONST16(0x0000)
++gl_acr2:
++
++|   cmpi     #2,d0
++   cmpi.l   #2,d0
++
++   bne.b    gl_acr3
++   move.l   ASM_PREFIX(_psp_saved_acr2), d0
++   rts
++   ASM_CONST16(0x0000)
++gl_acr3:
++   move.l   ASM_PREFIX(_psp_saved_acr3), d0
++   rts
++   ASM_CONST16(0x0000)
++#else // PSP_ACR_CNT == 4
++//#ifndef __ACF__   /* ACF uses register passing */
++#if PSP_ABI == PSP_ABI_STD
++   move.l   (4,sp),d0
++#endif
++|   cmpi     #0,d0
++   cmpi.l   #0,d0
++
++   bne.b    gl_acr1
++   move.l   (ASM_PREFIX(_psp_saved_acr0)),d0
++   rts
++   ASM_CONST16(0x0000)
++gl_acr1:
++   move.l (ASM_PREFIX(_psp_saved_acr1)),d0
++   rts
++   ASM_CONST16(0x0000)
++#endif // PSP_ACR_CNT == 4
++
++#endif // PSP_ACR_CNT
++
++|ISR*-----------------------------------------------------------------------
++|
++| Function Name    : _int_kernel_isr()
++| Comments         :
++|   This is the assembler level interrupt isr that intercepts all
++| interrupts. (When installed on a particular vector).
++|
++|   Enough registers are saved so that a 'C' isr can be called.
++|   If the current stack is not the interrupt stack, then the stack is
++|   switched over.
++|
++|   0 is pushed onto the stack, and a LINK A6 is done.
++|   This effectively is what a function call does, BUT the return address is 0.
++|   This will allow a 'C'function to walk back on the stack to find where this
++|   'interrupt frame' exists.
++|
++|   An interrupt 'context' is created on the stack, thus allowing for proper
++|   operation of MQX 'C' functions that access the error code and _int_enable
++|   and _int_disable
++|
++|   Then interrupt handlers are checked for.  If they have not been installed,
++|   or the current ISR number is out the range of installed handlers,
++|   the DEFAULT_ISR is called.
++|
++|   If they have been installed then if a user 'C' hander has not been installed
++|   for this vector, the DEFAULT_ISR is called.
++|
++|   After returning from the call to the 'C' isr the following is checked:
++|   If this is a nested ISR, then we do an interrupt return.
++|   If the current task is still the highest priority running task, we
++|   do an interrupt return.
++|   Otherwise we must save the full context for the current task, and
++|   enter the scheduler.
++|
++|END*------------------------------------------------------------------------
++
++        ASM_PUBLIC(_int_kernel_isr)
++        ASM_PUBLIC(_int_kernel_isr_return_internal)
++        ASM_ALIGN(4)
++
++_isr_save_extra_registers:
++        SAVE_REST_ISR_REGISTERS
++        bra.w   _isr_no_save_extra
++
++ASM_PREFIX(_int_kernel_isr):
++        move.l  d0,-(sp)                     | save D0
++        move.w  sr,d0                        | remember SR value
++        move.w  #0x2700,sr                    | set level to full disable
++
++        SAVE_ISR_REGISTERS                   | save the registers
++
++        GET_KERNEL_DATA a0                   | get the kernel data address
++
++#if MQX_GUERRILLA_INTERRUPTS_EXIST
++
++|        move.w  KD_DISABLE_SR(a0),sr         | reset to correct disable level
++         move.w  KD_DISABLE_SR(a0),d1         | reset to correct disable level
++         move.w  d1,sr                        |
++
++#endif
++
++        | save other registers if exception_isr is installed
++        clr.l   d1
++        btst.b  d1,(KD_FLAGS+1,a0)            | check for bit0 of 16 bit #
++        bne.w   _isr_save_extra_registers
++_isr_no_save_extra:
++        move.w  (FLINT_FORMAT_OFFSET,sp),d1   | get format and vector offset
++        andi.l  #0x3fc,d1                     | get vector number
++        lsr.l   #2,d1
++
++        move.w  (KD_IN_ISR,a0),d2             | Check for swap to int stack
++|        tst.w   KD_IN_ISR(a0)                | Check for swap to int stack
++        bne.b   _isr_no_stack_swap
++
++        movea.l (KD_ACTIVE_PTR,a0),a1         | Get TD pointer
++        move.l  sp,(TD_STACK_PTR,a1)          | and save the stack pointer
++
++#if PSP_HAS_DSP
++        movea.l d1,a2                        | save d1
++        SAVE_DSP_REGISTERS a1,a0             | wipes d1
++        GET_KERNEL_DATA a0                   | get the kernel data address
++        move.l  a2,d1                        | restore d1
++#endif
++
++        movea.l  (KD_INTERRUPT_STACK_PTR,a0),sp
++
++_isr_no_stack_swap:
++|        move.w  KD_IN_ISR(a0),d2             | Indicate that ISR running
++        addq.l  #1,d2
++        move.w  d2,(KD_IN_ISR,a0)
++
++        subq.l  #IC_STRUCT_SIZE-8,sp         | create interrupt context
++        subq.l  #8,sp
++
++        | Initialize the interrupt "context"
++        clr.l   (sp)                         | Clear the error code
++        move.w  d0,(4,sp)                     | save SR as ENABLE sr
++        move.w  d1,(6,sp)                     | save interrupt # in context
++        move.l  (KD_INTERRUPT_CONTEXT_PTR,a0),(IC_PREV_CONTEXT,sp) | set isr cntxt
++        move.l  sp,(KD_INTERRUPT_CONTEXT_PTR,a0) | store new context pointer
++
++#if MQX_KERNEL_LOGGING
++        btst.b  #0,(KD_LOG_CONTROL+3,a0)
++        beq.b   _isr_no_logging
++        lea      (-4*6,sp),sp                | make room on the stack
++        movem.l d0/d1/d2/a0/a1/a2,(0,sp)     | save registers used
++
++    //#ifdef __ACF__
++    #if PSP_ABI == PSP_ABI_REG
++        move.l  d1,d0
++    #else
++        move.l  d1,-(sp)                    | Interrupt number
++    #endif
++
++        jsr     (ASM_PREFIX(_klog_isr_start_internal)).L
++
++    //#ifdef __ACF__
++    #if PSP_ABI == PSP_ABI_REG
++       movem.l (0,sp),d0/d1/d2/a0/a1/a2     | restore scratch registers
++       adda.l  #6*4,sp
++    #else
++        movem.l (4,sp),d0/d1/d2/a0/a1/a2     | restore scratch registers
++        adda.l  #7*4,sp
++    #endif
++
++_isr_no_logging:
++#endif // MQX_KERNEL_LOGGING
++
++        move.w  d0,sr                        | Lower to running sr level
++
++#if MQX_SPARSE_ISR_TABLE
++|       Find the 'C' isr to run:
++        clr.l   d0
++        move.l  d1, d2
++        move.w  (KD_LAST_USER_ISR_VECTOR + 2, a0), d0
++        beq.w   _isr_run_default             | int table not installed
++        cmp.l   d0, d1                        | vector # too high??
++        bgt.w   _isr_run_default             | cmp calcs d0-d1 > 0 is bad
++        move.w  (KD_FIRST_USER_ISR_VECTOR + 2, a0), d0
++        sub.l   d0, d1                        | vector # too low??
++        bge.b   _int_kernel_isr_vect_ok     | cmp calcs d0-d1 < 0 is bad
++        bra.w   _isr_run_default
++
++|       we have the interrupt # relative to start of interrupt table
++|       Each table entry is 12 bytes in size, so to get to the correct
++|       int entry we have to multiply d1 by 12..
++_int_kernel_isr_vect_ok:
++
++        lsr.l   #MQX_SPARSE_ISR_SHIFT, d1
++
++        mulu.w  #4,d1
++
++        movea.l (KD_INTERRUPT_TABLE_PTR, a0), a1  | get the interrupt table pointer
++        adda.l  d1, a1                          | get address of entry in table - to linked list
++
++        movea.l (a1), a1                         | get address of first isr in linked list
++        tst.l   a1
++        beq.w   _isr_run_default                | isr not used
++
++_isr_search:
++
++        move.l  (HASH_ISR_NUM, a1), d0            | get isr num
++        tst.l   d0
++        beq.w   _isr_search_fail
++
++        cmp.l   d0, d2
++        beq.w   _isr_search_suc
++
++        movea.l (HASH_ISR_NEXT, a1), a1           | next vector in list
++        tst.l   a1
++        bne.w   _isr_search
++
++
++_isr_search_fail:
++        bra     _isr_run_default
++_isr_search_suc:
++
++//#ifdef  __ACF__
++#if PSP_ABI == PSP_ABI_REG
++        movea.l (HASH_ISR_DATA, a1), a0        | IAR reg convention
++#else
++        move.l  (HASH_ISR_DATA, a1), -(sp)     | push notifier data
++#endif
++
++
++        movea.l (HASH_ISR_ADDR, a1), a1               | get ISR handler
++
++#else
++|       Find the 'C' isr to run:
++        clr.l   d0
++        move.w  (KD_LAST_USER_ISR_VECTOR+2,a0),d0
++        beq.w   _isr_run_default             | int table not installed
++        cmp.l   d0,d1                        | vector # too high??
++        bgt.w   _isr_run_default             | cmp calcs d0-d1 > 0 is bad
++        move.w  (KD_FIRST_USER_ISR_VECTOR+2,a0),d0
++        sub.l   d0,d1                        | vector # too low??
++        bge.b   _int_kernel_isr_vect_ok     | cmp calcs d0-d1 < 0 is bad
++        bra.w   _isr_run_default
++
++|       we have the interrupt # relative to start of interrupt table
++|       Each table entry is 12 bytes in size, so to get to the correct
++|       int entry we have to multiply d1 by 12..
++_int_kernel_isr_vect_ok:
++        move.w  d1,d0
++        mulu.w  #12,d0                        | d0 is now 3*4 * int #
++
++        movea.l (KD_INTERRUPT_TABLE_PTR,a0),a1 | get the interrupt table pointer
++        adda.l  d0,a1                         | get address of entry in table
++//#ifdef  __ACF__
++#if PSP_ABI == PSP_ABI_REG
++        movea.l (IT_APP_ISR_DATA,a1), a0        | IAR reg convention
++#else
++        move.l  (IT_APP_ISR_DATA,a1), -(sp)     | push notifier data
++#endif
++
++        movea.l (IT_APP_ISR,a1),a1             | get ISR handler
++#endif
++
++_isr_execute:
++        jsr     (a1)                         | transfer to 'C' isr
++#if PSP_ABI == PSP_ABI_STD
++        adda.l  #4,sp                        | get rid of  'C' isr parameter
++#endif
++
++ASM_PREFIX(_int_kernel_isr_return_internal):
++        GET_KERNEL_DATA a0                   | get kernel data addres
++        move.w  (KD_DISABLE_SR,a0),d1         | set level to kernel disable
++        move.w  d1,sr                        | set level to kernel disable
++
++#if MQX_KERNEL_LOGGING
++        btst.b  #0,(KD_LOG_CONTROL+3,a0)
++        beq.b   no_logging4
++        clr.l   d1
++        move.w  (6,sp),d1                     | get interrupt #
++        lea     (-6*4,sp),sp                 | make room on the stack
++        movem.l d0/d1/d2/a0/a1/a2,(0,sp)      | save registers used
++
++     #if PSP_ABI == PSP_ABI_REG
++        move.l  d1,d0
++     #else
++        move.l  d1,-(sp)                     | Interrupt number
++     #endif
++        jsr     (ASM_PREFIX(_klog_isr_end_internal)).L
++
++     #if PSP_ABI == PSP_ABI_REG
++        movem.l (0,sp),d0/d1/d2/a0/a1/a2      | restore scratch registers
++        adda.l  #6*4,sp
++     #else
++        movem.l (4,sp),d0/d1/d2/a0/a1/a2      | restore scratch registers
++        adda.l  #7*4,sp
++     #endif
++no_logging4:
++#endif
++
++        move.l  (IC_PREV_CONTEXT,sp),(KD_INTERRUPT_CONTEXT_PTR,a0) | get previous ISR context
++        addq.l  #IC_STRUCT_SIZE-8,sp         | remove the interrupt context
++        addq.l  #8,sp                        |
++
++        clr.l   d0
++        move.w  (KD_IN_ISR,a0),d0             | out of 1 ISR
++        subq.l   #1,d0
++        move.w  d0,(KD_IN_ISR,a0)
++        bne.w   _isr_nested_interrupt
++
++|       Completed all nested interrupts
++        movea.l (KD_ACTIVE_PTR,a0),a1         | Get TD pointer
++        movea.l (TD_STACK_PTR,a1),sp          | Return to old stack
++
++|       Check SR value on stack for HW nested stack frames
++        clr.l   d0
++        clr.l   d1
++        move.b  (FLINT_SR_OFFSET,sp),d0
++        andi.l  #0x27,d0
++        move.b  (KD_ACTIVE_SR,a0),d1          | Just check lower 3 bits!!
++        cmp.l   d1,d0
++        bne.b   _isr_nested_interrupt
++
++|       Check to see if reschedule necessary
++        move.w  (TD_FLAGS+2,a1),d0
++        andi.l  #PREEMPTION_DISABLED,d0
++        bne.b   _isr_nested_interrupt        | task has preemption disabled
++
++|        If a different TD at head of current readyq, then we need to run
++|        the scheduler
++        move.l  a1,d0
++        movea.l (KD_CURRENT_READY_Q,a0),a1
++        cmp.l   (a1),d0
++        bne.w   _isr_context_switch          | diffent td at head of readyq
++
++        movea.l (KD_ACTIVE_PTR,a0),a1         | Get TD pointer
++#if PSP_HAS_DSP
++        RESTORE_DSP_REGISTERS a1,a2          | kills d0
++#endif
++
++        | save other registers if exception_isr is installed
++        clr.l   d0
++        btst.b  d0,(KD_FLAGS + 1, a0)            | check for bit0 of 16 bit #
++        bne.b   _isr_restore_extra
++        RESTORE_ISR_REGISTERS
++        rte
++        ASM_CONST16(0x0000)
++
++_isr_nested_interrupt:
++        movea.l (KD_ACTIVE_PTR,a0),a1         | Get TD pointer
++
++        | save other registers if exception_isr is installed
++        clr.l   d0
++        btst.b  d0,(KD_FLAGS+1,a0)            | check for bit0 of 16 bit #
++        bne.b   _isr_restore_extra
++        RESTORE_ISR_REGISTERS
++        rte
++        ASM_CONST16(0x0000)
++
++_isr_restore_extra:                          | restore extra registers
++        RESTORE_REST_ISR_REGISTERS
++        rte
++        ASM_CONST16(0x0000)
++
++_isr_run_default:
++        clr.l   d1
++        move.w  (6,sp),d1                     | get interrupt # in context
++
++#if PSP_ABI == PSP_ABI_REG
++        move.l  d1,d0
++#else
++        move.l  d1,-(sp)                     | d1 has vector #
++#endif
++
++        movea.l (KD_DEFAULT_ISR,a0),a1
++        bra.w   _isr_execute
++
++_isr_context_switch:
++        | No need to save other registers if exception_isr is installed
++        clr.l   d0
++        btst.b  d0,(KD_FLAGS+1,a0)            | check for bit0 of 16 bit #
++        bne.b   _isr_no_save_extra_again
++        SAVE_REST_ISR_REGISTERS
++_isr_no_save_extra_again:
++        GET_KERNEL_DATA a2
++        bra.w   __sched_internal
++
++| Do not include the cache code if the CPU has no cache
++#if PSP_HAS_CODE_CACHE || PSP_HAS_DATA_CACHE
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _icache_invalidate_mlines
++| Returned Value   :
++| Comments         :
++|   This function invalidate m lines from instruction cache
++|
++|END*----------------------------------------------------------------------
++
++        ASM_PUBLIC(_icache_invalidate_mlines)
++ASM_PREFIX(_icache_invalidate_mlines):
++        link     a6,#0
++
++#if PSP_ABI == PSP_ABI_STD
++        movea.l  8(a6),a1       | Base address to begin invalidating
++        move.l   12(a6),d2      | Number of lines to invalidate
++        move.l   16(a6),d1      | Size of one cache line
++#else
++        move.l  a0, a1
++        move.l  d0, d2
++#endif
++
++        moveq    #0,d0          | for (d0 = 0| d0 < mlines| d0++)
++        bra.s    test_mlines
++invalidate_another_line:
++
++#if PSP_CACHE_SPLIT
++|        ASM_CONST16(0xF4A9)      | cpushl ic,(a1)
++        cpushl  ic, (a1)
++#else
++|       ASM_CONST16(0xF4E9)         | cpushl bc,(a1)
++        cpushl  bc, (a1)
++#endif
++
++        adda.l   d1,a1
++        addq.l   #1,d0
++test_mlines:
++        cmp.l    d2,d0
++        bcs.s    invalidate_another_line
++        unlk     a6
++        rts
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _dcache_flush_mlines
++| Returned Value   :
++| Comments         :
++|   This function flush data cache m lines
++|
++|END*----------------------------------------------------------------------
++
++#if 0
++        ASM_PUBLIC(_dcache_flush_mlines)
++ASM_PREFIX(_dcache_flush_mlines):
++        link     a6,#0
++
++#if PSP_ABI == PSP_ABI_STD
++        movea.l  (8,a6),a1       | Base address to begin invalidating
++        move.l   (12,a6),d2      | Number of lines to flush
++        move.l   (16,a6),d1      | Size of one cache line
++#else
++        move.l  a0, a1
++        move.l  d0, d2
++#endif
++
++        moveq    #0,d0          | for (d0 = 0| d0 < mlines| d0++)
++        bra.s    (test_flush_mlines)
++flush_another_line:
++
++#if PSP_CACHE_SPLIT
++|        ASM_CONST16(0xF469)    | cpushl dc,(a1)
++        cpushl dc, (a1)
++#else
++|        ASM_CONST16(0xF4E9)    | cpushl bc,(a1)
++        cpushl bc, (a1)
++#endif
++
++        adda.l   d1,a1
++        addq.l   #1,d0
++test_flush_mlines:
++        cmp.l    d2,d0
++        bcs.s    flush_another_line
++        unlk     a6
++        rts
++#endif
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _psp_dcache_flush_all
++| Comments         :
++|    This function will flush the entire data cache.
++|
++|END*------------------------------------------------------------------------
++        ASM_PUBLIC(_psp_dcache_flush_all)
++ASM_PREFIX(_psp_dcache_flush_all):
++    link     a6,#0
++
++#if PSP_ABI == PSP_ABI_STD
++    lea      -16(a7),a7         |Allocate frame to store D3,D4,D5
++    movem.l  d3-d5,4(a7)        |Cannot trash D3,D4,D5
++    move.l    8(a6),d2          |param1 => int cache_line_size
++    move.l   12(a6),d3          |param2 => int num_ways
++    move.l   16(a6),d4          |param3 => int num_sets
++#else
++    lea      -16(a7),a7         |Allocate frame to store D3,D4,D5
++    movem.l  d3-d5, 4(a7)        |Cannot trash D3,D4,D5
++
++    move.l  d2, d4
++    move.l  d1, d3
++    move.l  d0, d2
++#endif
++
++    nop                         |synchronize/flush store buffer
++
++    move.w   sr,d5              |** Disable interrupts
++    move.l   #0x2700,d0         |Cannot have the data cache changing
++    move.w   d0,sr
++
++    moveq.l  #0,d0              |initialize way counter
++    moveq.l  #0,d1              |initialize set counter
++    move.l   d0,a0              |initialize cpushl pointer
++setloop:
++#if PSP_CACHE_SPLIT
++    cpushl   dc, (a0)           |push cache line a0
++#else
++    cpushl   bc, (a0)           |push cache line a0
++#endif
++
++    add.l    d2,a0              |increment set index by 1
++    addq.l   #1,d1              |increment set counter
++    cmp.l    d4,d1              |are sets for this way done?
++    blt      setloop
++    moveq.l  #0,d1              |set counter to zero again
++    addq.l   #1,d0              |increment to next way
++    move.l   d0,a0              |set = 0, way = d0
++    cmp.l    d3,d0              |flushed all the ways?
++    blt      setloop
++
++    move.w   d5,sr              |** Re-enable interrupts
++    movem.l  4(a7),d3-d5
++    unlk     a6
++    rts
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _dcache_flush
++| Comments         :
++|    This function will flush the data cache
++|
++|END*------------------------------------------------------------------------
++        ASM_PUBLIC(_dcache_flush)
++ASM_PREFIX(_dcache_flush):
++
++#if PSP_ABI == PSP_ABI_STD
++        movea.l (4, sp), a0         | start address
++        move.l  (8, sp), d0         | line cnt
++        move.l  (12, sp), d1        | cache_line_size
++#endif
++
++        move.w  sr, d2              | disable interrupts
++        |lea     -8(sp), sp          | allocate frame to store SR
++        move.l  d2, -(sp)
++
++        move.l  #0x2700, d2         |Cannot have the data cache changing
++        move.w  d2, sr
++
++
++        move.l  a0, d2
++        and.l   #0xfffffff0, d2
++        movea.l d2, a0
++
++        moveq   #0, d2              | for (d2 = 0| d2 < mlines (d0)| d2++)
++        bra.s   dcache_flush_test
++
++dcache_flush_line:
++        movea.l a0, a1
++
++        // TODO add support for split cache
++#if PSP_CACHE_SPLIT
++        cpushl  dc, (a1)
++
++        adda.l  #1, a1
++        cpushl  dc, (a1)
++
++        adda.l  #1, a1
++        cpushl  dc, (a1)
++
++        adda.l  #1, a1
++        cpushl  dc, (a1)
++#else
++        cpushl  bc, (a1)
++
++        adda.l  #1, a1
++        cpushl  bc, (a1)
++
++        adda.l  #1, a1
++        cpushl  bc, (a1)
++
++        adda.l  #1, a1
++        cpushl  bc, (a1)
++#endif
++
++        adda.l  d1, a0
++        addq.l  #1, d2
++dcache_flush_test:
++        cmp.l   d0, d2
++        bcs.s   dcache_flush_line
++
++        move.l (sp)+, d2
++        move.w  d2, sr              | enable interrupts
++
++        rts
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : _dcache_flush_phy
++| Returned Value   :
++| Comments         :
++|   This function flush data cache by physical address (mcf54455 feature)
++|
++|END*----------------------------------------------------------------------
++
++        ASM_PUBLIC(_dcache_flush_phy)
++ASM_PREFIX(_dcache_flush_phy):
++
++#if PSP_ABI == PSP_ABI_STD
++        movea.l (4, sp), a0         | Base address to begin invalidating
++        move.l  (8, sp), d0         | Number of lines to flush
++        move.l  (12, sp), d1        | Size of one cache line
++#endif
++
++        moveq   #0, d2              | for (d2 = 0| d2 < mlines (d0)| d2++)
++        bra.s   dcache_flush_phy_test
++
++dcache_flush_phy_line:
++        cpushl  dc, (a0)
++
++        adda.l  d1, a0
++        addq.l  #1, d2
++dcache_flush_phy_test:
++        cmp.l   d0, d2
++        bcs.s   dcache_flush_phy_line
++
++        rts
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : __psp_enable_acrs
++| Returned Value   :
++| Comments         :
++|   This function enable ACR registers
++|
++|END*----------------------------------------------------------------------
++
++        ASM_PUBLIC(__psp_enable_acrs)
++ASM_PREFIX(__psp_enable_acrs):
++    link     a6,#0
++#if PSP_ABI == PSP_ABI_STD
++    movea.l  (8,a6),a1           | [IN] int ACR_VAL[4] param
++#else
++    movea.l     a0, a1
++#endif
++
++
++    move.l   (a1),d0
++    movec    d0,#CF_ACR0
++    move.l   4(a1),d0
++    movec    d0,#CF_ACR1
++ #if PSP_ACR_CNT == 4
++    move.l   8(a1),d0
++    movec    d0,#CF_ACR2
++    move.l   12(a1),d0
++    movec    d0,#CF_ACR3
++ #endif // PSP_ACR_CNT == 4
++    nop                         | Sync pipeline
++    unlk     a6
++    rts
++
++|FUNCTION*-------------------------------------------------------------------
++|
++| Function Name    : __psp_clear_acrs
++| Returned Value   :
++| Comments         :
++|   This function clear ACR registers
++|
++|END*----------------------------------------------------------------------
++
++        ASM_PUBLIC(__psp_clear_acrs)
++ASM_PREFIX(__psp_clear_acrs):
++    moveq.l  #0,d0
++    movec    d0,#CF_ACR0
++    movec    d0,#CF_ACR1
++
++#if PSP_ACR_CNT == 4
++    movec    d0,#CF_ACR2
++    movec    d0,#CF_ACR3
++#endif // PSP_ACR_CNT == 4
++
++    nop                         | Sync pipeline
++    rts
++
++#endif
++
 diff --git a/mqx/source/psp/coldfire/ipsum.S b/mqx/source/psp/coldfire/ipsum.S
-index d13af532..d3c18550 100644
+index d13af532..0853d7e7 100644
 --- a/mqx/source/psp/coldfire/ipsum.S
 +++ b/mqx/source/psp/coldfire/ipsum.S
-@@ -34,10 +34,15 @@
-         ; End CR 2042
+@@ -1,54 +1,59 @@
+-;*HEADER********************************************************************
+-;* 
+-;* Copyright 2008 Freescale Semiconductor, Inc.
+-;* Copyright 1989-2008 ARC International
+-;*
+-;* This software is owned or controlled by Freescale Semiconductor.
+-;* Use of this software is governed by the Freescale MQX RTOS License
+-;* distributed with this Material.
+-;* See the MQX_RTOS_LICENSE file distributed for more details.
+-;*
+-;* Brief License Summary:
+-;* This software is provided in source form for you to use free of charge,
+-;* but it is not open source software. You are allowed to use this software
+-;* but you cannot redistribute it or derivative works of it in source form.
+-;* The software may be used only in connection with a product containing
+-;* a Freescale microprocessor, microcontroller, or digital signal processor.
+-;* See license agreement file for full license terms including other restrictions.
+-;**************************************************************************
+-;*
+-;* Comments:
+-;*
+-;*   This file contains the implementation for a one's
+-;*   complement checksum.
+-;*   The function can handle ANY alignment for the data area.
+-;*   It is optimized for the 68020 and above in order to
+-;*   perform in the best possible manner.
+-;*
+-;*END***********************************************************************
++|*HEADER********************************************************************
++|* 
++|* Copyright 2008 Freescale Semiconductor, Inc.
++|* Copyright 1989-2008 ARC International
++|*
++|* This software is owned or controlled by Freescale Semiconductor.
++|* Use of this software is governed by the Freescale MQX RTOS License
++|* distributed with this Material.
++|* See the MQX_RTOS_LICENSE file distributed for more details.
++|*
++|* Brief License Summary:
++|* This software is provided in source form for you to use free of charge,
++|* but it is not open source software. You are allowed to use this software
++|* but you cannot redistribute it or derivative works of it in source form.
++|* The software may be used only in connection with a product containing
++|* a Freescale microprocessor, microcontroller, or digital signal processor.
++|* See license agreement file for full license terms including other restrictions.
++|**************************************************************************
++|*
++|* Comments:
++|*
++|*   This file contains the implementation for a one's
++|*   complement checksum.
++|*   The function can handle ANY alignment for the data area.
++|*   It is optimized for the 68020 and above in order to
++|*   perform in the best possible manner.
++|*
++|*END***********************************************************************
+ 
+ #include <asm_mac.h>
+ #include "user_config.h"
+-        ; Start CR 2042
+-        ;.file "ipsum.s"
+-        ; End CR 2042
++        | Start CR 2042
++        |.file "ipsum.s"
++        | End CR 2042
  #ifdef __ACF__
          RSEG IPSUM:CODE (4)
 +#else
@@ -83,18 +2819,1035 @@ index d13af532..d3c18550 100644
  #endif
 +#endif
  
- ;FUNCTION*--------------------------------------------------------------
- ;
+-;FUNCTION*--------------------------------------------------------------
+-;
+-; Function Name    : __mem_sum_ip(a, len, src)
+-; Returned Value   : one's complement checksum
+-; Comments         :
+-;       This function calculates a 16 bit checksum over the specified data.
+-;
+-;       Note:  This function returns 0 iff all summands are 0.
+-;
+-;END*-------------------------------------------------------------------
++|FUNCTION*--------------------------------------------------------------
++|
++| Function Name    : __mem_sum_ip(a, len, src)
++| Returned Value   : one's complement checksum
++| Comments         :
++|       This function calculates a 16 bit checksum over the specified data.
++|
++|       Note:  This function returns 0 iff all summands are 0.
++|
++|END*-------------------------------------------------------------------
+ 
+         ASM_PUBLIC(_mem_sum_ip)
+ 
+@@ -57,58 +62,58 @@ ASM_PREFIX(_mem_sum_ip):
+ #if PSP_ABI == PSP_ABI_STD
+         clr.l   d1
+         clr.l   d0
+-        movea.l (12,sp),a0       ; a0 is the source address
+-        move.w  (10,sp),d1       ; d1 is the number of bytes to checksum
+-        move.w  (6,sp),d0        ; d0 is the initial sum
++        movea.l (12,sp),a0       | a0 is the source address
++        move.w  (10,sp),d1       | d1 is the number of bytes to checksum
++        move.w  (6,sp),d0        | d0 is the initial sum
+ #endif
+ 
+         move.l  a1,-(sp)
+         move.l  d2,-(sp)
+         move.l  d3,-(sp)
+ 
+-;
+-;   Here is the CW stack frame for this function:
+-;
+-;       +20 src (A0)
+-;       +16 len (D1)
+-;       +12 a   (D0)
+-;   IAR call frame starts here:
+-;       +8  return PC
+-;       +4  old D2
+-;   A7   => old D3
+-;
+-
+-        cmp.l   #3,d1           ; Do we have 3 or less bytes?
++|
++|   Here is the CW stack frame for this function:
++|
++|       +20 src (A0)
++|       +16 len (D1)
++|       +12 a   (D0)
++|   IAR call frame starts here:
++|       +8  return PC
++|       +4  old D2
++|   A7   => old D3
++|
++
++        cmp.l   #3,d1           | Do we have 3 or less bytes?
+         ble.w   try_words
+ 
+-;
+-;   Note:  If the source address isn't word aligned, we could align it,
+-;   perform a byte-swapped sum, and byte-swap the result (this works).
+-;   However, since RTCS never uses non word aligned addresses, this
+-;   isn't implemented.
+-;
++|
++|   Note:  If the source address isn't word aligned, we could align it,
++|   perform a byte-swapped sum, and byte-swap the result (this works).
++|   However, since RTCS never uses non word aligned addresses, this
++|   isn't implemented.
++|
+ 
+-        move.l  a0,d2           ; Try to get onto even word
++        move.l  a0,d2           | Try to get onto even word
+         btst.l  #1,d2
+-        beq.b   try_longs       ; YES, address is long aligned already
+-        clr.l   d3              ; NO, align that puppy
++        beq.b   try_longs       | YES, address is long aligned already
++        clr.l   d3              | NO, align that puppy
+         move.w  (a0)+,d3
+         add.l   d3,d0
+         subq.l  #2,d1
+ 
+ try_longs:
+         move.l  d1,d2
+-        lsr.l   #6,d2           ; 64 bytes summed per loop
++        lsr.l   #6,d2           | 64 bytes summed per loop
+         movea.l d2,a1
+ 
+-        move.l  d1,d3           ; 1 long processed by 4 bytes
++        move.l  d1,d3           | 1 long processed by 4 bytes
+         and.l   #0x3C,d3
+         neg.l   d3
+         
+ #ifdef __ACF__
+-        move.b  #0,ccr          ; Clear X
++        move.b  #0,ccr          | Clear X
+ #else
+-        move.w  #0,ccr          ; Clear X
++        move.w  #0,ccr          | Clear X
+ #endif
+ 
+ #ifdef __ACF__
+@@ -158,22 +163,22 @@ do_longs_end:
+         bge.b     do_longs
+ 
+ do_word:
+-        btst    #1,d1           ; Sum last word
++        btst    #1,d1           | Sum last word
+         beq.b     do_byte
+         clr.l   d3
+         move.w  (a0)+,d3
+         addx.l  d3,d0
+ 
+ do_byte:
+-        btst    #0,d1           ; Sum last byte
++        btst    #0,d1           | Sum last byte
+         beq.b   done
+         clr.l   d3
+-        addx.l  d3,d0            ; add the carry if there is one.
++        addx.l  d3,d0            | add the carry if there is one.
+         move.b  (a0)+,d3
+         asl.l   #8,d3
+         add.l   d3,d0
+ 
+-done:   move.l  d0,d1           ; Fold 32 bit sum into 16
++done:   move.l  d0,d1           | Fold 32 bit sum into 16
+         swap    d1
+         and.l   #0xFFFF,d0
+         and.l   #0xFFFF,d1
+@@ -191,11 +196,11 @@ done:   move.l  d0,d1           ; Fold 32 bit sum into 16
+ 
+ try_words:
+ #ifdef __ACF__
+-        move.b  #0,ccr          ; Clear X
++        move.b  #0,ccr          | Clear X
+ #else
+-        move.w  #0,ccr          ; Clear X
++        move.w  #0,ccr          | Clear X
+ #endif
+         bra.b   do_word
+ 
+  
+-; EOF
++| EOF
 diff --git a/mqx/source/psp/coldfire/psp_prv.inc b/mqx/source/psp/coldfire/psp_prv.inc
-index f9512b0d..9c5fb858 100644
+index f9512b0d..5676a226 100644
 --- a/mqx/source/psp/coldfire/psp_prv.inc
 +++ b/mqx/source/psp/coldfire/psp_prv.inc
-@@ -274,7 +274,7 @@ SAVE_ALL_REGISTERS: .macro
-         lea.l   -4*16(sp),sp            ; make room on the stack
-         movem.l d3-d7,4*3(sp)           ; save regs (can optimize and
-         movem.l a2-a6,4*10(sp)          ; not save d0,d1,d2,a0,a1)
--        move.w  #$4000,d0               ; set coldfire stack frame
-+        move.w  #0x4000,d0              ; set coldfire stack frame
+@@ -1,33 +1,33 @@
+-;*HEADER********************************************************************
+-;*
+-;* Copyright 2008-2011 Freescale Semiconductor, Inc.
+-;* Copyright 1989-2008 ARC International
+-;*
+-;* This software is owned or controlled by Freescale Semiconductor.
+-;* Use of this software is governed by the Freescale MQX RTOS License
+-;* distributed with this Material.
+-;* See the MQX_RTOS_LICENSE file distributed for more details.
+-;*
+-;* Brief License Summary:
+-;* This software is provided in source form for you to use free of charge,
+-;* but it is not open source software. You are allowed to use this software
+-;* but you cannot redistribute it or derivative works of it in source form.
+-;* The software may be used only in connection with a product containing
+-;* a Freescale microprocessor, microcontroller, or digital signal processor.
+-;* See license agreement file for full license terms including other restrictions.
+-;**************************************************************************
+-;*
+-;* Comments:
+-;*
+-;*   This assembler header file contains private declarations for
+-;*   use with the mqx assembler files
+-;*
+-;*END***********************************************************************
++|*HEADER********************************************************************
++|*
++|* Copyright 2008-2011 Freescale Semiconductor, Inc.
++|* Copyright 1989-2008 ARC International
++|*
++|* This software is owned or controlled by Freescale Semiconductor.
++|* Use of this software is governed by the Freescale MQX RTOS License
++|* distributed with this Material.
++|* See the MQX_RTOS_LICENSE file distributed for more details.
++|*
++|* Brief License Summary:
++|* This software is provided in source form for you to use free of charge,
++|* but it is not open source software. You are allowed to use this software
++|* but you cannot redistribute it or derivative works of it in source form.
++|* The software may be used only in connection with a product containing
++|* a Freescale microprocessor, microcontroller, or digital signal processor.
++|* See license agreement file for full license terms including other restrictions.
++|**************************************************************************
++|*
++|* Comments:
++|*
++|*   This assembler header file contains private declarations for
++|*   use with the mqx assembler files
++|*
++|*END***********************************************************************
+ 
+ #include <asm_mac.h>
+-;------------------------------------------------------------------------
+-;                         EXTERNAL REFERENCES
+-;
++|------------------------------------------------------------------------
++|                         EXTERNAL REFERENCES
++|
+ 
+ #if MQX_KERNEL_LOGGING
+         ASM_EXTERN(_klog_block_internal)
+@@ -42,13 +42,13 @@
+         ASM_EXTERN(_mqx_context_switch_internal)
+ 
+ 
+-;------------------------------------------------------------------------
+-;                       CONSTANT DECLARATIONS
+-;
++|------------------------------------------------------------------------
++|                       CONSTANT DECLARATIONS
++|
+ 
+-; The following are the bits in the CONFIG field of the kernel data structure
+-; to set for the psp options.
+-; NOTE: These must agree with values in mqx_prv.h
++| The following are the bits in the CONFIG field of the kernel data structure
++| to set for the psp options.
++| NOTE: These must agree with values in mqx_prv.h
+ 
+ #define __ASM__
+ #include "mqx_prv.h"
+@@ -66,26 +66,26 @@
+ #endif
+ 
+ 
+-; Offset to the stack frame format and vector word from the stack pointer.
+-; 15 registers slots are allocated before the SR and PC on the stack
++| Offset to the stack frame format and vector word from the stack pointer.
++| 15 registers slots are allocated before the SR and PC on the stack
+ 
+ ASM_EQUATE(FLINT_SR_OFFSET    , 4*15+2)
+ ASM_EQUATE(FLINT_FORMAT_OFFSET, FLINT_SR_OFFSET-2)
+ ASM_EQUATE(FLINT_PC_OFFSET    , FLINT_FORMAT_OFFSET+4)
+ 
+-;  Task FLAGS bits
+-;  These must match definitions in mqx_prv.h
++|  Task FLAGS bits
++|  These must match definitions in mqx_prv.h
+ 
+-; MUST match
++| MUST match
+ #if PSP_HAS_FPU
+-ASM_EQUATE(FP_TASK_MASK, MQX_FLOATING_POINT_TASK)  ; mqx.h -> mqx_prv.h
++ASM_EQUATE(FP_TASK_MASK, MQX_FLOATING_POINT_TASK)  | mqx.h -> mqx_prv.h
+ #endif
+ 
+-ASM_EQUATE(FP_CONTEXT_SAVED_MASK, TASK_FLOATING_POINT_CONTEXT_SAVED)    ; mqx_prv.h
++ASM_EQUATE(FP_CONTEXT_SAVED_MASK, TASK_FLOATING_POINT_CONTEXT_SAVED)    | mqx_prv.h
+ ASM_EQUATE(FP_CONTEXT_CLEAR_MASK, 0xfdff)
+-ASM_EQUATE(PREEMPTION_DISABLED,   TASK_PREEMPTION_DISABLED)             ; mqx_prv.h
++ASM_EQUATE(PREEMPTION_DISABLED,   TASK_PREEMPTION_DISABLED)             | mqx_prv.h
+ 
+-; DSP register offsets from Stack Base
++| DSP register offsets from Stack Base
+ #if PSP_HAS_DSP
+ ASM_EQUATE(TD_DSP_MASK     , -4  )
+ ASM_EQUATE(TD_DSP_MACSR    , -8  )
+@@ -97,35 +97,35 @@ ASM_EQUATE(TD_DSP_ACC1     , -28 )
+ ASM_EQUATE(TD_DSP_ACC0     , -32 )
+ #endif
+ 
+-;------------------------------------------------------------------------
+-;                          MACRO DECLARATIONS
+-;
++|------------------------------------------------------------------------
++|                          MACRO DECLARATIONS
++|
+ #ifdef __ACF__
+ /* IAR Assembler Macros */
+ 
+-; This macro returns the address of the kernel data in the specified register
++| This macro returns the address of the kernel data in the specified register
+ GET_KERNEL_DATA MACRO REG
+-        movea.l  ASM_PREFIX(_mqx_kernel_data),REG    ; get the kernel data pointer
++        movea.l  ASM_PREFIX(_mqx_kernel_data),REG    | get the kernel data pointer
+                 ENDM
+ 
+-; Start CR 1169
+-; This macro returns the address of the system task stack ptr in the specified register
++| Start CR 1169
++| This macro returns the address of the system task stack ptr in the specified register
+ GET_SYSTEM_STACK MACRO REG
+         movea.l  ASM_PREFIX(_mqx_system_stack), REG
+          ENDM
+-; End CR 1169
++| End CR 1169
+ 
+-; This macro saves the context for the running task when called from a C
+-; function. Since it is called from a C function, the C scratch registers
+-; d0,d1,d2,a0,a1 do not have to be saved
++| This macro saves the context for the running task when called from a C
++| function. Since it is called from a C function, the C scratch registers
++| d0,d1,d2,a0,a1 do not have to be saved
+ SAVE_ALL_REGISTERS MACRO
+-        lea.l   (-4*16,sp),sp            ; make room on the stack
+-        movem.l d3-d7,(4*3,sp)           ; save regs (can optimize and
+-        movem.l a2-a6,(4*10,sp)          ; not save d0,d1,d2,a0,a1)
+-        move.w  #0x4000,d0               ; set coldfire stack frame
++        lea.l   (-4*16,sp),sp            | make room on the stack
++        movem.l d3-d7,(4*3,sp)           | save regs (can optimize and
++        movem.l a2-a6,(4*10,sp)          | not save d0,d1,d2,a0,a1)
++        move.w  #0x4000,d0               | set coldfire stack frame
          swap    d0
          move.w  sr,d0
-         move.l  d0,4*15(sp)             ; save SR and format
+-        move.l  d0,(4*15,sp)             ; save SR and format
++        move.l  d0,(4*15,sp)             | save SR and format
+         ENDM
+ 
+ SAVE_DSP_REGISTERS MACRO TD_REG, TEMPA_REG
+@@ -135,28 +135,28 @@ SAVE_DSP_REGISTERS MACRO TD_REG, TEMPA_REG
+ 
+   #if PSP_HAS_EMAC
+ 
+-;        move.l  ACCext01,d1
++|        move.l  ACCext01,d1
+         ASM_CONST16(0xAB81)
+         move.l  d1,(TD_DSP_ACCEXT01,TEMPA_REG)
+-;        move.l  ACCext23,d1
++|        move.l  ACCext23,d1
+         ASM_CONST16(0xAF81)
+         move.l  d1,(TD_DSP_ACCEXT23,TEMPA_REG)
+-;        move.l  ACC0,d1
++|        move.l  ACC0,d1
+         ASM_CONST16(0xA181)
+         move.l  d1,(TD_DSP_ACC0,TEMPA_REG)
+-;        move.l  ACC1,d1
++|        move.l  ACC1,d1
+         ASM_CONST16(0xA381)
+         move.l  d1,(TD_DSP_ACC1,TEMPA_REG)
+-;        move.l  ACC2,d1
++|        move.l  ACC2,d1
+         ASM_CONST16(0xA581)
+         move.l  d1,(TD_DSP_ACC2,TEMPA_REG)
+-;        move.l  ACC3,d1
++|        move.l  ACC3,d1
+         ASM_CONST16(0xA781)
+         move.l  d1,(TD_DSP_ACC3,TEMPA_REG)
+ 
+         move.l  MACSR,d1
+         move.l  d1,(TD_DSP_MACSR,TEMPA_REG)
+-;        move.l  MASK,d1
++|        move.l  MASK,d1
+         ASM_CONST16(0xAD81)
+         move.l  d1,(TD_DSP_MASK,TEMPA_REG)
+ 
+@@ -171,9 +171,9 @@ SAVE_DSP_REGISTERS MACRO TD_REG, TEMPA_REG
+ 
+         ENDM
+ 
+-; This macro restores the context for a task
++| This macro restores the context for a task
+ RESTORE_ALL_REGISTERS: MACRO
+-        movem.l  (sp),a0-a6/d0-d7        ; restore regs
++        movem.l  (sp),a0-a6/d0-d7        | restore regs
+         adda.l    #60,sp
+         ENDM
+ 
+@@ -185,27 +185,27 @@ RESTORE_DSP_REGISTERS MACRO TD_REG, TEMPA_REG
+   #if PSP_HAS_EMAC
+ 
+         move.l  (TD_DSP_ACC0,TEMPA_REG),d0
+-;        move.l  d0,ACC0
++|        move.l  d0,ACC0
+         ASM_CONST16(0xA100)
+         move.l  (TD_DSP_ACC1,TEMPA_REG),d0
+-;        move.l  d0,ACC1
++|        move.l  d0,ACC1
+         ASM_CONST16(0xA300)
+         move.l  (TD_DSP_ACC2,TEMPA_REG),d0
+-;        move.l  d0,ACC2
++|        move.l  d0,ACC2
+         ASM_CONST16(0xA500)
+         move.l  (TD_DSP_ACC3,TEMPA_REG),d0
+-;        move.l  d0,ACC3
++|        move.l  d0,ACC3
+         ASM_CONST16(0xA700)
+ 
+         move.l  (TD_DSP_ACCEXT01,TEMPA_REG),d0
+-;        move.l  d0,ACCEXT01
++|        move.l  d0,ACCEXT01
+         ASM_CONST16(0xAB00)
+         move.l  (TD_DSP_ACCEXT23,TEMPA_REG),d0
+-;        move.l  d0,ACCext23
++|        move.l  d0,ACCext23
+         ASM_CONST16(0xAF00)
+ 
+         move.l  (TD_DSP_MASK,TEMPA_REG),d0
+-;        move.l  d0,MASK
++|        move.l  d0,MASK
+         ASM_CONST16(0xAD00)
+         move.l  (TD_DSP_MACSR,TEMPA_REG),d0
+         move.l  d0,MACSR
+@@ -221,10 +221,10 @@ RESTORE_DSP_REGISTERS MACRO TD_REG, TEMPA_REG
+         ENDM
+ 
+ SAVE_ISR_REGISTERS MACRO
+-        lea      (-14*4,sp),sp           ; make room on the stack
+-        move.l   (14*4,sp),(sp)          ; move D0 to proper location in
+-                                        ; saved stack frame
+-        movem.l  d1-d2,(4,sp)            ; save isr registers (just scratch and d2)
++        lea      (-14*4,sp),sp           | make room on the stack
++        move.l   (14*4,sp),(sp)          | move D0 to proper location in
++                                        | saved stack frame
++        movem.l  d1-d2,(4,sp)            | save isr registers (just scratch and d2)
+         movem.l  a0-a2,(4*8,sp)
+         ENDM
+ 
+@@ -235,16 +235,16 @@ RESTORE_ISR_REGISTERS MACRO
+         ENDM
+ 
+ SAVE_REST_ISR_REGISTERS MACRO
+-        movem.l d3-d7,(3*4,sp)           ; save rest
++        movem.l d3-d7,(3*4,sp)           | save rest
+         movem.l a3-a6,(11*4,sp)
+         ENDM
+ 
+ RESTORE_REST_ISR_REGISTERS MACRO
+-        movem.l  (sp),a0-a6/d0-d7       ; restore regs
++        movem.l  (sp),a0-a6/d0-d7       | restore regs
+         adda.l    #60,sp
+         ENDM
+ 
+-; This macro calls the kernel logging function, if logging enabled
++| This macro calls the kernel logging function, if logging enabled
+ KLOG   MACRO KDATA, KLOG_FUNCTION
+ #if MQX_KERNEL_LOGGING
+         LOCAL no_log
+@@ -257,66 +257,66 @@ no_log:
+ 
+ #else /* __ACF__ */
+ 
+-; This macro returns the address of the kernel data in the specified register
++| This macro returns the address of the kernel data in the specified register
+ GET_KERNEL_DATA: .macro REG
+-        move.l  ASM_PREFIX(_mqx_kernel_data),REG    ; get the kernel data pointer
++        move.l  ASM_PREFIX(_mqx_kernel_data),\REG    | get the kernel data pointer
+         .endm
+ 
+-; This macro returns the address of the system task stack ptr in the specified register
++| This macro returns the address of the system task stack ptr in the specified register
+ GET_SYSTEM_STACK: .macro REG
+-        move.l  ASM_PREFIX(_mqx_system_stack), REG
++        move.l  ASM_PREFIX(_mqx_system_stack), \REG
+         .endm
+ 
+-; This macro saves the context for the running task when called from a C
+-; function. Since it is called from a C function, the C scratch registers
+-; d0,d1,d2,a0,a1 do not have to be saved
++| This macro saves the context for the running task when called from a C
++| function. Since it is called from a C function, the C scratch registers
++| d0,d1,d2,a0,a1 do not have to be saved
+ SAVE_ALL_REGISTERS: .macro
+-        lea.l   -4*16(sp),sp            ; make room on the stack
+-        movem.l d3-d7,4*3(sp)           ; save regs (can optimize and
+-        movem.l a2-a6,4*10(sp)          ; not save d0,d1,d2,a0,a1)
+-        move.w  #$4000,d0               ; set coldfire stack frame
++        lea.l   -4*16(sp),sp            | make room on the stack
++        movem.l d3-d7,4*3(sp)           | save regs (can optimize and
++        movem.l a2-a6,4*10(sp)          | not save d0,d1,d2,a0,a1)
++        move.w  #0x4000,d0              | set coldfire stack frame
+         swap    d0
+         move.w  sr,d0
+-        move.l  d0,4*15(sp)             ; save SR and format
++        move.l  d0,4*15(sp)             | save SR and format
+         .endm
+ 
+ SAVE_DSP_REGISTERS: .macro TD_REG TEMPA_REG
+         #if PSP_HAS_DSP
+ 
+-        move.l  TD_STACK_BASE(TD_REG),TEMPA_REG
++        move.l  TD_STACK_BASE(\TD_REG),\TEMPA_REG
+ 
+         #if PSP_HAS_EMAC
+ 
+-;        move.l  ACCext01,d1
++|        move.l  ACCext01,d1
+         .word   0xAB81
+-        move.l  d1,TD_DSP_ACCEXT01(TEMPA_REG)
+-;        move.l  ACCext23,d1
++        move.l  d1,TD_DSP_ACCEXT01(\TEMPA_REG)
++|        move.l  ACCext23,d1
+         .word   0xAF81
+-        move.l  d1,TD_DSP_ACCEXT23(TEMPA_REG)
++        move.l  d1,TD_DSP_ACCEXT23(\TEMPA_REG)
+ 
+-;        move.l  ACC0,d1
++|        move.l  ACC0,d1
+         .word   0xA181
+-        move.l  d1,TD_DSP_ACC0(TEMPA_REG)
+-;        move.l  ACC1,d1
++        move.l  d1,TD_DSP_ACC0(\TEMPA_REG)
++|        move.l  ACC1,d1
+         .word   0xA381
+-        move.l  d1,TD_DSP_ACC1(TEMPA_REG)
+-;        move.l  ACC2,d1
++        move.l  d1,TD_DSP_ACC1(\TEMPA_REG)
++|        move.l  ACC2,d1
+         .word   0xA581
+-        move.l  d1,TD_DSP_ACC2(TEMPA_REG)
+-;        move.l  ACC3,d1
++        move.l  d1,TD_DSP_ACC2(\TEMPA_REG)
++|        move.l  ACC3,d1
+         .word   0xA781
+-        move.l  d1,TD_DSP_ACC3(TEMPA_REG)
++        move.l  d1,TD_DSP_ACC3(\TEMPA_REG)
+ 
+         move.l  MACSR,d1
+-        move.l  d1,TD_DSP_MACSR(TEMPA_REG)
+-;        move.l  MASK,d1
++        move.l  d1,TD_DSP_MACSR(\TEMPA_REG)
++|        move.l  MASK,d1
+         .word   0xAD81
+-        move.l  d1,TD_DSP_MASK(TEMPA_REG)
++        move.l  d1,TD_DSP_MASK(\TEMPA_REG)
+ 
+         #else   // PSP_HAS_EMAC
+ 
+         move.l  ACC, d1
+-        move.l  d1, TD_DSP_ACC0(TEMPA_REG)
++        move.l  d1, TD_DSP_ACC0(\TEMPA_REG)
+ 
+         #endif  // PSP_HAS_EMAC
+ 
+@@ -324,48 +324,48 @@ SAVE_DSP_REGISTERS: .macro TD_REG TEMPA_REG
+ 
+         .endm
+ 
+-; This macro restores the context for a task
++| This macro restores the context for a task
+ RESTORE_ALL_REGISTERS: .macro
+-        movem.l  (sp),a0-a6/d0-d7        ; restore regs
++        movem.l  (sp),a0-a6/d0-d7        | restore regs
+         add.l    #60,sp
+         .endm
+ 
+ RESTORE_DSP_REGISTERS: .macro TD_REG TEMPA_REG
+         #if PSP_HAS_DSP
+ 
+-        move.l  TD_STACK_BASE(TD_REG),TEMPA_REG
++        move.l  TD_STACK_BASE(\TD_REG),\TEMPA_REG
+ 
+         #if PSP_HAS_EMAC
+ 
+-        move.l  TD_DSP_ACC0(TEMPA_REG),d0
+-;        move.l  d0,ACC0
++        move.l  TD_DSP_ACC0(\TEMPA_REG),d0
++|        move.l  d0,ACC0
+         .word   0xA100
+-        move.l  TD_DSP_ACC1(TEMPA_REG),d0
+-;        move.l  d0,ACC1
++        move.l  TD_DSP_ACC1(\TEMPA_REG),d0
++|        move.l  d0,ACC1
+         .word   0xA300
+-        move.l  TD_DSP_ACC2(TEMPA_REG),d0
+-;        move.l  d0,ACC2
++        move.l  TD_DSP_ACC2(\TEMPA_REG),d0
++|        move.l  d0,ACC2
+         .word   0xA500
+-        move.l  TD_DSP_ACC3(TEMPA_REG),d0
+-;        move.l  d0,ACC3
++        move.l  TD_DSP_ACC3(\TEMPA_REG),d0
++|        move.l  d0,ACC3
+         .word   0xA700
+ 
+-        move.l  TD_DSP_ACCEXT01(TEMPA_REG),d0
+-;        move.l  d0,ACCEXT01
++        move.l  TD_DSP_ACCEXT01(\TEMPA_REG),d0
++|        move.l  d0,ACCEXT01
+         .word   0xAB00
+-        move.l  TD_DSP_ACCEXT23(TEMPA_REG),d0
+-;        move.l  d0,ACCext23
++        move.l  TD_DSP_ACCEXT23(\TEMPA_REG),d0
++|        move.l  d0,ACCext23
+         .word   0xAF00
+ 
+-        move.l  TD_DSP_MASK(TEMPA_REG),d0
+-;        move.l  d0,MASK
++        move.l  TD_DSP_MASK(\TEMPA_REG),d0
++|        move.l  d0,MASK
+         .word   0xAD00
+-        move.l  TD_DSP_MACSR(TEMPA_REG),d0
++        move.l  TD_DSP_MACSR(\TEMPA_REG),d0
+         move.l  d0,MACSR
+ 
+         #else   // PSP_HAS_EMAC
+ 
+-        move.l  TD_DSP_ACC0(TEMPA_REG), d0
++        move.l  TD_DSP_ACC0(\TEMPA_REG), d0
+         move.l  d0, ACC
+ 
+         #endif  // PSP_HAS_EMAC
+@@ -374,10 +374,10 @@ RESTORE_DSP_REGISTERS: .macro TD_REG TEMPA_REG
+         .endm
+ 
+ SAVE_ISR_REGISTERS: .macro
+-        lea      -14*4(sp),sp           ; make room on the stack
+-        move.l   14*4(sp),(sp)          ; move D0 to proper location in
+-                                        ; saved stack frame
+-        movem.l  d1-d2,4(sp)            ; save isr registers (just scratch and d2)
++        lea      -14*4(sp),sp           | make room on the stack
++        move.l   14*4(sp),(sp)          | move D0 to proper location in
++                                        | saved stack frame
++        movem.l  d1-d2,4(sp)            | save isr registers (just scratch and d2)
+         movem.l  a0-a2,4*8(sp)
+         .endm
+ 
+@@ -388,24 +388,24 @@ RESTORE_ISR_REGISTERS: .macro
+         .endm
+ 
+ SAVE_REST_ISR_REGISTERS: .macro
+-        movem.l d3-d7,3*4(sp)           ; save rest
++        movem.l d3-d7,3*4(sp)           | save rest
+         movem.l a3-a6,11*4(sp)
+         .endm
+ 
+ RESTORE_REST_ISR_REGISTERS: .macro
+-        movem.l  (sp),a0-a6/d0-d7       ; restore regs
++        movem.l  (sp),a0-a6/d0-d7       | restore regs
+         add.l    #60,sp
+         .endm
+ 
+-; This macro calls the kernel logging function, if logging enabled
++| This macro calls the kernel logging function, if logging enabled
+ KLOG:   .macro KDATA,KLOG_FUNCTION
+         .if MQX_KERNEL_LOGGING
+-        btst.b  #0,KD_LOG_CONTROL+3(KDATA)
++        btst.b  #0,KD_LOG_CONTROL+3(\KDATA)
+         beq.b   no_log\@
+-        jsr     KLOG_FUNCTION
++        jsr     \KLOG_FUNCTION
+ no_log\@:
+         .endif
+         .endm
+ 
+ #endif /* __ACF__ */
+-; EOF
++| EOF
+diff --git a/mqx/source/psp/coldfire/types.inc b/mqx/source/psp/coldfire/types.inc
+index 324b2f5b..3e526719 100644
+--- a/mqx/source/psp/coldfire/types.inc
++++ b/mqx/source/psp/coldfire/types.inc
+@@ -1,46 +1,46 @@
+ 
+-;*HEADER********************************************************************
+-;* 
+-;* Copyright 2008-2011 Freescale Semiconductor, Inc.
+-;* Copyright 1989-2008 ARC International
+-;*
+-;* This software is owned or controlled by Freescale Semiconductor.
+-;* Use of this software is governed by the Freescale MQX RTOS License
+-;* distributed with this Material.
+-;* See the MQX_RTOS_LICENSE file distributed for more details.
+-;*
+-;* Brief License Summary:
+-;* This software is provided in source form for you to use free of charge,
+-;* but it is not open source software. You are allowed to use this software
+-;* but you cannot redistribute it or derivative works of it in source form.
+-;* The software may be used only in connection with a product containing
+-;* a Freescale microprocessor, microcontroller, or digital signal processor.
+-;* See license agreement file for full license terms including other restrictions.
+-;**************************************************************************
+-;*
+-;* Comments:
+-;*
+-;*   This file contains the assembler offsets calculated by the
+-;*   program KRNL_OFF.C.  These offsets are to be included in
+-;*   any assembler program that wishes to access kernel data
+-;*   structures.
+-;*
+-;*END***********************************************************************
++|*HEADER********************************************************************
++|* 
++|* Copyright 2008-2011 Freescale Semiconductor, Inc.
++|* Copyright 1989-2008 ARC International
++|*
++|* This software is owned or controlled by Freescale Semiconductor.
++|* Use of this software is governed by the Freescale MQX RTOS License
++|* distributed with this Material.
++|* See the MQX_RTOS_LICENSE file distributed for more details.
++|*
++|* Brief License Summary:
++|* This software is provided in source form for you to use free of charge,
++|* but it is not open source software. You are allowed to use this software
++|* but you cannot redistribute it or derivative works of it in source form.
++|* The software may be used only in connection with a product containing
++|* a Freescale microprocessor, microcontroller, or digital signal processor.
++|* See license agreement file for full license terms including other restrictions.
++|**************************************************************************
++|*
++|* Comments:
++|*
++|*   This file contains the assembler offsets calculated by the
++|*   program KRNL_OFF.C.  These offsets are to be included in
++|*   any assembler program that wishes to access kernel data
++|*   structures.
++|*
++|*END***********************************************************************
+ 
+ #include <asm_mac.h>
+ #include "user_config.h"
+-;
+-; 'PSP_INT_CONTEXT_STRUCT' size = 12 , 0xc
+-;
++|
++| 'PSP_INT_CONTEXT_STRUCT' size = 12 , 0xc
++|
+ ASM_EQUATE(IC_STRUCT_SIZE,                         12)
+ ASM_EQUATE(IC_ERROR_CODE,                           0)
+ ASM_EQUATE(IC_ENABLE_SR,                            4)
+ ASM_EQUATE(IC_PREV_CONTEXT,                         8)
+ 
+ 
+-;
+-; 'INTERRUPT_TABLE_STRUCT' size = 12 , 0xc
+-;
++|
++| 'INTERRUPT_TABLE_STRUCT' size = 12 , 0xc
++|
+ ASM_EQUATE(IT_STRUCT_SIZE,                         12)
+ ASM_EQUATE(IT_APP_ISR,                              0)
+ ASM_EQUATE(IT_APP_ISR_EXCEPTION_HANDLER,            4)
+@@ -53,9 +53,9 @@ ASM_EQUATE(HASH_ISR_EXCEPT_HNDL,                   8)
+ ASM_EQUATE(HASH_ISR_DATA,                          12)
+ ASM_EQUATE(HASH_ISR_NEXT,                          16)
+ 
+-;
+-; 'READY_Q_STRUCT' size = 16 , 0x10
+-;
++|
++| 'READY_Q_STRUCT' size = 16 , 0x10
++|
+ ASM_EQUATE(RQ_STRUCT_SIZE,                         16)
+ ASM_EQUATE(RQ_HEAD_READY_Q,                         0) 
+ ASM_EQUATE(RQ_TAIL_READY_Q,                         4) 
+@@ -64,9 +64,9 @@ ASM_EQUATE(RQ_ENABLE_SR,                           12)
+ ASM_EQUATE(RQ_PRIORITY,                            14) 
+ 
+ 
+-;
+-; 'TD_STRUCT' size = 216 , 0xd8
+-;
++|
++| 'TD_STRUCT' size = 216 , 0xd8
++|
+ ASM_EQUATE(TD_TD_NEXT,                              0)
+ ASM_EQUATE(TD_TD_PREV,                              4)
+ ASM_EQUATE(TD_STATE,                                8)
+@@ -82,84 +82,84 @@ ASM_EQUATE(TD_FLAGS,                               40)
+ ASM_EQUATE(TD_MMU_VIRTUAL_CONTEXT_PTR,             44)
+ ASM_EQUATE(TD_DSP_CONTEXT_PTR,                     48)
+ ASM_EQUATE(TD_FLOAT_CONTEXT_PTR,                   52)
+-;
+-; 'KERNEL_DATA_STRUCT' size = 1156 , 0x484
+-;
+-ASM_EQUATE(KD_ADDRESSING_CAPABILITY,                0)  ;  0x0
+-ASM_EQUATE(KD_ENDIANESS,                            4)  ;  0x4
+-ASM_EQUATE(KD_CPU_TYPE,                             8)  ;  0x8
+-ASM_EQUATE(KD_PSP_CFG_MEMORY_ALIGNMENT,            10)  ;  0xa
+-ASM_EQUATE(KD_PSP_CFG_STACK_ALIGNMENT,             12)  ;  0xc
+-ASM_EQUATE(KD_PSP_CFG_MEM_STOREBLOCK_ALIGNMENT,    14)  ;  0xe
+-ASM_EQUATE(KD_CONFIG1,                             16)  ;  0x10
+-ASM_EQUATE(KD_CONFIG2,                             18)  ;  0x12
+-ASM_EQUATE(KD_FLAGS,                               20)  ;  0x14
+-ASM_EQUATE(KD_DISABLE_SR,                          22)  ;  0x16
+-ASM_EQUATE(KD_IN_ISR,                              24)  ;  0x18
+-ASM_EQUATE(KD_ACTIVE_SR,                           26)  ;  0x1a
+-ASM_EQUATE(KD_ACTIVE_PTR,                          28)  ;  0x1c
+-ASM_EQUATE(KD_READY_Q_LIST,                        32)  ;  0x20
+-ASM_EQUATE(KD_CURRENT_READY_Q,                     36)  ;  0x24
+-ASM_EQUATE(KD_DEFAULT_ISR,                         40)  ;  0x28
+-ASM_EQUATE(KD_FIRST_USER_ISR_VECTOR,               44)  ;  0x2c
+-ASM_EQUATE(KD_LAST_USER_ISR_VECTOR,                48)  ;  0x30
+-ASM_EQUATE(KD_INTERRUPT_CONTEXT_PTR,               52)  ;  0x34
+-ASM_EQUATE(KD_INTERRUPT_TABLE_PTR,                 56)  ;  0x38
+-ASM_EQUATE(KD_INTERRUPT_STACK_PTR,                 60)  ;  0x3c
++|
++| 'KERNEL_DATA_STRUCT' size = 1156 , 0x484
++|
++ASM_EQUATE(KD_ADDRESSING_CAPABILITY,                0)  |  0x0
++ASM_EQUATE(KD_ENDIANESS,                            4)  |  0x4
++ASM_EQUATE(KD_CPU_TYPE,                             8)  |  0x8
++ASM_EQUATE(KD_PSP_CFG_MEMORY_ALIGNMENT,            10)  |  0xa
++ASM_EQUATE(KD_PSP_CFG_STACK_ALIGNMENT,             12)  |  0xc
++ASM_EQUATE(KD_PSP_CFG_MEM_STOREBLOCK_ALIGNMENT,    14)  |  0xe
++ASM_EQUATE(KD_CONFIG1,                             16)  |  0x10
++ASM_EQUATE(KD_CONFIG2,                             18)  |  0x12
++ASM_EQUATE(KD_FLAGS,                               20)  |  0x14
++ASM_EQUATE(KD_DISABLE_SR,                          22)  |  0x16
++ASM_EQUATE(KD_IN_ISR,                              24)  |  0x18
++ASM_EQUATE(KD_ACTIVE_SR,                           26)  |  0x1a
++ASM_EQUATE(KD_ACTIVE_PTR,                          28)  |  0x1c
++ASM_EQUATE(KD_READY_Q_LIST,                        32)  |  0x20
++ASM_EQUATE(KD_CURRENT_READY_Q,                     36)  |  0x24
++ASM_EQUATE(KD_DEFAULT_ISR,                         40)  |  0x28
++ASM_EQUATE(KD_FIRST_USER_ISR_VECTOR,               44)  |  0x2c
++ASM_EQUATE(KD_LAST_USER_ISR_VECTOR,                48)  |  0x30
++ASM_EQUATE(KD_INTERRUPT_CONTEXT_PTR,               52)  |  0x34
++ASM_EQUATE(KD_INTERRUPT_TABLE_PTR,                 56)  |  0x38
++ASM_EQUATE(KD_INTERRUPT_STACK_PTR,                 60)  |  0x3c
+ 
+-ASM_EQUATE(KD_LOG_CONTROL,                         64)  ;  0x40
+-ASM_EQUATE(LOG_OLD_TD,                             68)  ;  0x44
+-ASM_EQUATE(KD_FP_ACTIVE_PTR,                       72)  ;  0x48
+-ASM_EQUATE(KD_DSP_ACTIVE_PTR,                      76)  ;  0x4c
+-ASM_EQUATE(KD_SYSTEM_TD,                           80)  ;  0x50
++ASM_EQUATE(KD_LOG_CONTROL,                         64)  |  0x40
++ASM_EQUATE(LOG_OLD_TD,                             68)  |  0x44
++ASM_EQUATE(KD_FP_ACTIVE_PTR,                       72)  |  0x48
++ASM_EQUATE(KD_DSP_ACTIVE_PTR,                      76)  |  0x4c
++ASM_EQUATE(KD_SYSTEM_TD,                           80)  |  0x50
+ 
+-;
+-; 'PSP_BLOCKED_FP_STRUCT'
+-ASM_EQUATE(FP_FPCR_OFFSET,                       0 )    ; 0x00
+-ASM_EQUATE(FP_FPSR_OFFSET,                       4 )    ; 0x04
+-ASM_EQUATE(FP_FPIAR_OFFSET,                      8 )    ; 0x08
+-ASM_EQUATE(FP_TID_OFFSET,                        12)    ; 0x0C
+-ASM_EQUATE(FP_FPR0_OFFSET,                       16)    ; 0x10
+-ASM_EQUATE(FP_FPR1_OFFSET,                       24)    ; 0x18
+-ASM_EQUATE(FP_FPR2_OFFSET,                       32)    ; 0x20
+-ASM_EQUATE(FP_FPR3_OFFSET,                       40)    ; 0x28
+-ASM_EQUATE(FP_FPR4_OFFSET,                       48)    ; 0x30
+-ASM_EQUATE(FP_FPR5_OFFSET,                       56)    ; 0x38
+-ASM_EQUATE(FP_FPR6_OFFSET,                       64)    ; 0x40
+-ASM_EQUATE(FP_FPR7_OFFSET,                       72)    ; 0x48
++|
++| 'PSP_BLOCKED_FP_STRUCT'
++ASM_EQUATE(FP_FPCR_OFFSET,                       0 )    | 0x00
++ASM_EQUATE(FP_FPSR_OFFSET,                       4 )    | 0x04
++ASM_EQUATE(FP_FPIAR_OFFSET,                      8 )    | 0x08
++ASM_EQUATE(FP_TID_OFFSET,                        12)    | 0x0C
++ASM_EQUATE(FP_FPR0_OFFSET,                       16)    | 0x10
++ASM_EQUATE(FP_FPR1_OFFSET,                       24)    | 0x18
++ASM_EQUATE(FP_FPR2_OFFSET,                       32)    | 0x20
++ASM_EQUATE(FP_FPR3_OFFSET,                       40)    | 0x28
++ASM_EQUATE(FP_FPR4_OFFSET,                       48)    | 0x30
++ASM_EQUATE(FP_FPR5_OFFSET,                       56)    | 0x38
++ASM_EQUATE(FP_FPR6_OFFSET,                       64)    | 0x40
++ASM_EQUATE(FP_FPR7_OFFSET,                       72)    | 0x48
+ #ifdef __ACF__
+-;
+-;  Control Registers
+-ASM_EQUATE(CACR, 0x002) ; Cache control register
+-ASM_EQUATE(ASID, 0x003) ; Address space identifier register
+-ASM_EQUATE(acr0, 0x004) ; Access control registers 0
+-ASM_EQUATE(acr1, 0x005) ; Access control registers 1
+-ASM_EQUATE(ACR2, 0x006) ; Access control registers 2
+-ASM_EQUATE(ACR3, 0x007) ; Access control registers 3
+-ASM_EQUATE(mbar, 0x008) ; MMU base address register
+-ASM_EQUATE(VBR,  0x801)  ; Vector base register
+-ASM_EQUATE(PC,   0x80F) ; Program counter
++|
++|  Control Registers
++ASM_EQUATE(CACR, 0x002) | Cache control register
++ASM_EQUATE(ASID, 0x003) | Address space identifier register
++ASM_EQUATE(acr0, 0x004) | Access control registers 0
++ASM_EQUATE(acr1, 0x005) | Access control registers 1
++ASM_EQUATE(ACR2, 0x006) | Access control registers 2
++ASM_EQUATE(ACR3, 0x007) | Access control registers 3
++ASM_EQUATE(mbar, 0x008) | MMU base address register
++ASM_EQUATE(VBR,  0x801)  | Vector base register
++ASM_EQUATE(PC,   0x80F) | Program counter
+ 
+-ASM_EQUATE(ROMBAR0, 0xC00) ; ROM base address register 0
+-ASM_EQUATE(ROMBAR1, 0xC01) ; ROM base address register 1
+-ASM_EQUATE(RAMBAR0, 0xC04) ; RAM base address register 0
+-ASM_EQUATE(RAMBAR1, 0xC05) ; RAM base address register 1
+-ASM_EQUATE(MPCR, 0xC0C) ; Multiprocessor control register 1
+-ASM_EQUATE(EDRAMBAR, 0xC0D) ; Embedded DRAM base address register 1
+-ASM_EQUATE(SECMBAR,  0xC0E) ; Secondary module base address register 1
+-ASM_EQUATE(MBAR, 0xC0F) ; Primary module base address register
++ASM_EQUATE(ROMBAR0, 0xC00) | ROM base address register 0
++ASM_EQUATE(ROMBAR1, 0xC01) | ROM base address register 1
++ASM_EQUATE(RAMBAR0, 0xC04) | RAM base address register 0
++ASM_EQUATE(RAMBAR1, 0xC05) | RAM base address register 1
++ASM_EQUATE(MPCR, 0xC0C) | Multiprocessor control register 1
++ASM_EQUATE(EDRAMBAR, 0xC0D) | Embedded DRAM base address register 1
++ASM_EQUATE(SECMBAR,  0xC0E) | Secondary module base address register 1
++ASM_EQUATE(MBAR, 0xC0F) | Primary module base address register
+ 
+-ASM_EQUATE(PCR1U0, 0xD02) ; 32 msbs of RAM 0 permutation control register 1
+-ASM_EQUATE(PCR1L0, 0xD03) ; 32 lsbs of RAM 0 permutation control register 1
+-ASM_EQUATE(PCR2U0, 0xD04) ; 32 msbs of RAM 0 permutation control register 2
+-ASM_EQUATE(PCR2L0, 0xD05) ; 32 lsbs of RAM 0 permutation control register 2
+-ASM_EQUATE(PCR3U0, 0xD06) ; 32 msbs of RAM 0 permutation control register 3
+-ASM_EQUATE(PCR3L0, 0xD07) ; 32 lsbs of RAM 0 permutation control register 3
+-ASM_EQUATE(PCR1U1, 0xD0A) ; 32 msbs of RAM 1 permutation control register 1
+-ASM_EQUATE(PCR1L1, 0xD0B) ; 32 lsbs of RAM 1 permutation control register 1
+-ASM_EQUATE(PCR2U1, 0xD0C) ; 32 msbs of RAM 1 permutation control register 2
+-ASM_EQUATE(PCR2L1, 0xD0D) ; 32 lsbs of RAM 1 permutation control register 2
+-ASM_EQUATE(PCR3U1, 0xD0E) ; 32 msbs of RAM 1 permutation control register 3
+-ASM_EQUATE(PCR3L1, 0xD0F) ; 32 lsbs of RAM 1 permutation control register 3
++ASM_EQUATE(PCR1U0, 0xD02) | 32 msbs of RAM 0 permutation control register 1
++ASM_EQUATE(PCR1L0, 0xD03) | 32 lsbs of RAM 0 permutation control register 1
++ASM_EQUATE(PCR2U0, 0xD04) | 32 msbs of RAM 0 permutation control register 2
++ASM_EQUATE(PCR2L0, 0xD05) | 32 lsbs of RAM 0 permutation control register 2
++ASM_EQUATE(PCR3U0, 0xD06) | 32 msbs of RAM 0 permutation control register 3
++ASM_EQUATE(PCR3L0, 0xD07) | 32 lsbs of RAM 0 permutation control register 3
++ASM_EQUATE(PCR1U1, 0xD0A) | 32 msbs of RAM 1 permutation control register 1
++ASM_EQUATE(PCR1L1, 0xD0B) | 32 lsbs of RAM 1 permutation control register 1
++ASM_EQUATE(PCR2U1, 0xD0C) | 32 msbs of RAM 1 permutation control register 2
++ASM_EQUATE(PCR2L1, 0xD0D) | 32 lsbs of RAM 1 permutation control register 2
++ASM_EQUATE(PCR3U1, 0xD0E) | 32 msbs of RAM 1 permutation control register 3
++ASM_EQUATE(PCR3L1, 0xD0F) | 32 lsbs of RAM 1 permutation control register 3
+ 
+ #endif
+diff --git a/rtcs/source/if/getaddrinfo.c b/rtcs/source/if/getaddrinfo.c
+index f06dc0d5..72f7d886 100644
+--- a/rtcs/source/if/getaddrinfo.c
++++ b/rtcs/source/if/getaddrinfo.c
+@@ -72,7 +72,7 @@ static int add_ipv6(const char *hostname, int flags, struct addrinfo **aip, int
+ #endif
+ static void set_order(int, int (**)(const char *, int, struct addrinfo **, int, int));
+ static int add_ip(int family, const char *hostname, int flags, struct addrinfo **aip, int socktype, int port);
+-static char * strdup( const char *s);
++static char * rtcs_ai_strdup( const char *s);
+ 
+ 
+ #define FOUND_IPV4  0x1
+@@ -396,7 +396,7 @@ common:
+                                     NI_NUMERICHOST
+                                 ) == 0) 
+                 {
+-                    ai->ai_canonname = strdup(nbuf);
++                    ai->ai_canonname = rtcs_ai_strdup(nbuf);
+                     if (ai->ai_canonname == NULL) 
+                     {
+                         freeaddrinfo(ai_list);
+@@ -657,7 +657,7 @@ static int add_ip(int family, const char *hostname, int flags, struct addrinfo *
+                 /* If using /etc/hosts, the hostname on the list is
+                  * considered as the canonical name.*/
+ 
+-                ai->ai_canonname = strdup(hostname);
++                ai->ai_canonname = rtcs_ai_strdup(hostname);
+                 if (ai->ai_canonname == NULL)
+                 {
+                     freeaddrinfo(*aip);
+@@ -739,7 +739,7 @@ static int add_ip(int family, const char *hostname, int flags, struct addrinfo *
+                         {
+                             if(dns_record->name)  
+                             {
+-                                ai->ai_canonname = strdup(dns_record->name);
++                                ai->ai_canonname = rtcs_ai_strdup(dns_record->name);
+                                 if (ai->ai_canonname == NULL)
+                                 {
+                                     freeaddrinfo(*aip);
+@@ -877,7 +877,7 @@ static struct addrinfo *ai_reverse(struct addrinfo *oai)
+ }
+ 
+ 
+-static char * strdup(const char *s)
++static char * rtcs_ai_strdup(const char *s)
+ {
+     unsigned int len = strlen (s) + 1;
+   
+diff --git a/rtcs/source/if/inet_ntop.c b/rtcs/source/if/inet_ntop.c
+index f045d7a1..ac99b4a1 100644
+--- a/rtcs/source/if/inet_ntop.c
++++ b/rtcs/source/if/inet_ntop.c
+@@ -229,16 +229,21 @@ static char *inet_ntop6 (
+ }
+ 
+ 
+-/*************************************************************************************	
+- * $OpenBSD: strlcpy.c,v 1.11 2006/05/05 15:27:38 millert Exp $	
++#if !defined(__BSD_VISIBLE) || !__BSD_VISIBLE
++/*************************************************************************************
++ * $OpenBSD: strlcpy.c,v 1.11 2006/05/05 15:27:38 millert Exp $
+  *
+  * Copy src to string dst of size siz.  At most siz-1 characters
+  * will be copied.  Always NUL terminates (unless siz == 0).
+  * Returns strlen(src); if retval >= siz, truncation occurred.
++ *
++ * Compiled out when the C library already provides strlcpy() (newlib
++ * declares it under __BSD_VISIBLE, which is on by default) — see the
++ * matching guard around the prototype in rtcs.h.
+  *************************************************************************************/
+ unsigned int strlcpy (
+-                    char *dst           /*[OUT]  */, 
+-                    const char *src     /*[IN] */, 
++                    char *dst           /*[OUT]  */,
++                    const char *src     /*[IN] */,
+                     unsigned int siz          /*[IN]  */
+                )
+ {
+@@ -264,4 +269,5 @@ unsigned int strlcpy (
+ 
+ 	return(s - src - 1);	/* count does not include NUL */
+ }
++#endif
+ 
+diff --git a/rtcs/source/include/rtcs.h b/rtcs/source/include/rtcs.h
+index fc45eb72..3d509881 100644
+--- a/rtcs/source/include/rtcs.h
++++ b/rtcs/source/include/rtcs.h
+@@ -497,12 +497,18 @@ extern char *inet_ntop
+ 	socklen_t	    size		/* max. size of the textual presentation of an address		*/
+ );
+ 
++#if !defined(__BSD_VISIBLE) || !__BSD_VISIBLE
++/* newlib only declares strlcpy() when __BSD_VISIBLE; when it does
++ * (e.g. this m68k-elf/newlib toolchain, __BSD_VISIBLE=1 by default),
++ * RTCS's own copy (implemented in if/inet_ntop.c) must not be
++ * re-declared here with a conflicting (unsigned int vs size_t) signature. */
+ extern unsigned int strlcpy
+ (
+ 	char 				   *dst, 		/* pointer to destination buffer 					*/
+ 	const char 			   *src, 		/* pointer to source string		 					*/
+ 	unsigned int	       siz			/* size of the destination buffer					*/
+ );
++#endif
+ 
+ extern void freeaddrinfo
+ (


### PR DESCRIPTION
## Résumé

Premier build **vert** du firmware **BP (SC944D / MCF52259 ColdFire)** avec la toolchain **GCC/GAS libre** (`m68k-elf-gcc`), en local sous Docker. Résout ce qui restait de compatibilité CodeWarrior → GCC non purgée par la Phase 0.

Artefacts produits (`build.sh bp`, `VERSION=local-dev`) :
- `bp/build/bp/BP_MQX_ETH-local-dev.elf` (873 908 o)
- `bp/build/bp/BP_MQX_ETH-local-dev.s19` (71 390 o, S3 records)
- `bp/build/bp/BP_MQX_ETH-local-dev.map`

Occupation : **text 28424 · data 88 · bss 64** — très largement dans le budget Flash 512 Ko / SRAM 64 Ko. `make test` (host) tous verts.

## Périmètre

- ✅ Chaîne de **build** validée de bout en bout.
- ⛔ Sources applicatives métier (`Alarme.c`, `Chauffage.c`, …) **non intégrées** — `main.c` reste l'appli minimale. Étape suivante.
- ⛔ Serveur FTP RTCS (`ftpsrv_*`) exclu proprement (dépend de MFS, absent de ce build minimal). Le client FTP reste inclus.

## Changements

### Patch MQX — `bp/patches/0001-mqx-gcc-compat.patch` (4 → 9 fichiers, 100 → ~3850 lignes)
Cœur de la PR. Nouveaux fichiers couverts : `types.inc`, `lwgpio_mcf5225.c`, `rtcs.h`, `inet_ntop.c`, `getaddrinfo.c`.
- Commentaires CodeWarrior `;` → `|` (GAS traite `;` comme séparateur d'instruction ; le vrai char de commentaire est `|`).
- Params de macro GAS préfixés `\` (`\REG`).
- `movec` avec registres de contrôle ColdFire (`cacr`/`acr0-3`/`mbar`/`rambar0-1`) encodés en immédiats numériques (GAS ne les connaît que pour 68020/030/040/060).
- Cast-as-lvalue supprimé dans `lwgpio_mcf5225.c`.
- Collisions `strlcpy`/`strdup` vs newlib : guard `__BSD_VISIBLE` + helper statique renommé `rtcs_ai_strdup`.

> `psp_comp.h` reste patché séparément par `build.sh` (branche `#elif defined(__GNUC__)`) et est **volontairement hors** de ce patch.

### `bp/Makefile`
- `-I spi_legacy/polled` (header `spi_pol_prv.h`).
- `BSP_S_SRC` + règle `%.asm.o: %.S` — **évite la collision silencieuse `boot.c`/`boot.o`** (Make droppait l'assembleur sans erreur → échec de link trompeur).
- `FIO_C_SRC` (`fio/*.c`, référencé extern par les drivers io) + `timer_pit.c`.
- `RTCS_APPS_EXCLUDE` (7 fichiers `ftpsrv_*`).
- Link `-lc` ajouté (memcpy manquant sous `-nostdlib`), **sans** retirer `-nostdlib`.

### `bp/bsp/m52259evb/boot.S`
- Symboles linker réels d'`intflash.ld` (`_sidata`/`_sdata`/`_edata`/`_sbss`/`_ebss`) au lieu de symboles inventés.
- `movec` rambar0/1 en immédiat (`#0xC04`/`#0xC05`).

### Divers
- `bp/compat/cf_assert.c` : `mqx.h` avant `bsp.h`.
- `bp/main.c` : forward-declaration de `main_task`.

## Garde-fous
- Flags obligatoires **préservés** : `-mcpu=52259 -msoft-float -ffreestanding -nostdlib`.
- Layout mémoire du bootloader (`intflash.ld`) **inchangé**.
- Aucun fichier `.github/workflows/` touché.
- Le submodule `mqx` n'est **pas** bumpé : ses changements sont entièrement reproduits par le patch versionné (appliqué au build). Un checkout frais + `build.sh bp` reconstruit l'état buildable.

## À noter
- Toolchain réellement produite : **GCC 13.2.0** (alors que `ct-ng.config` documente 14.2.0) — sans impact sur ce build, mais écart à vérifier si la version documentée est requise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)